### PR TITLE
Refactor C code to support multiple HALs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,50 +15,40 @@ NIF=priv/spi_nif.so
 ifeq ($(CROSSCOMPILE),)
     # Not crosscompiling, so check that we're on Linux.
     ifneq ($(shell uname -s),Linux)
-        $(warning Elixir Circuits only works on Linux, but crosscompilation)
-        $(warning is supported by defining $$CROSSCOMPILE, $$ERL_EI_INCLUDE_DIR,)
-        $(warning and $$ERL_EI_LIBDIR. See Makefile for details. If using Nerves,)
-        $(warning this should be done automatically.)
-        $(warning .)
-        $(warning Skipping C compilation unless targets explicitly passed to make.)
-	DEFAULT_TARGETS = priv
+        $(warning Elixir Circuits only works on Nerves and Linux platforms.)
+        $(warning A stub NIF will be compiled for test purposes.)
+	HAL = src/hal_stub.c
+        LDFLAGS += -undefined dynamic_lookup -dynamiclib
+    else
+        LDFLAGS += -fPIC -shared
     endif
+else
+# Crosscompiled build
+LDFLAGS += -fPIC -shared
 endif
-DEFAULT_TARGETS ?= priv $(NIF)
+HAL ?= src/hal_spidev.c
 
-# Look for the EI library and header files
-# For crosscompiled builds, ERL_EI_INCLUDE_DIR and ERL_EI_LIBDIR must be
-# passed into the Makefile.
-ifeq ($(ERL_EI_INCLUDE_DIR),)
-ERL_ROOT_DIR = $(shell erl -eval "io:format(\"~s~n\", [code:root_dir()])" -s init stop -noshell)
-ifeq ($(ERL_ROOT_DIR),)
-   $(error Could not find the Erlang installation. Check to see that 'erl' is in your PATH)
-endif
-ERL_EI_INCLUDE_DIR = "$(ERL_ROOT_DIR)/usr/include"
-ERL_EI_LIBDIR = "$(ERL_ROOT_DIR)/usr/lib"
-endif
+CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
 
 # Set Erlang-specific compile and linker flags
 ERL_CFLAGS ?= -I$(ERL_EI_INCLUDE_DIR)
-ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR) -lei
+ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR)
 
-LDFLAGS += -fPIC -shared -pedantic
-CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter
-
-SRC=$(wildcard src/*.c)
+SRC =src/spi_nif.c $(HAL)
+HEADERS =$(wildcard src/*.h)
 
 calling_from_make:
 	mix compile
 
-all: $(DEFAULT_TARGETS)
-
-$(NIF): $(wildcard src/*.h)
+all: priv $(NIF)
 
 priv:
 	mkdir -p priv
 
+$(NIF): $(HEADERS)
+
 $(NIF): $(SRC)
-	$(CC) $(ERL_CFLAGS) $(CFLAGS) $(ERL_LDFLAGS) $(LDFLAGS) -o $@ $^
+	$(CC) -o $@ $(SRC) $(ERL_CFLAGS) $(CFLAGS) $(ERL_LDFLAGS) $(LDFLAGS)
 
 clean:
 	$(RM) $(NIF)

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -70,6 +70,14 @@ defmodule Circuits.SPI do
     |> Enum.map(fn p -> String.replace_prefix(p, "/dev/", "") end)
   end
 
+  @doc """
+  Return info about the low level SPI interface
+
+  This may be helpful when debugging SPI issues.
+  """
+  @spec info() :: map()
+  defdelegate info(), to: Nif
+
   defmodule :circuits_spi do
     @moduledoc """
     Provide an Erlang friendly interface to Circuits

--- a/lib/spi/spi_nif.ex
+++ b/lib/spi/spi_nif.ex
@@ -20,4 +20,8 @@ defmodule Circuits.SPI.Nif do
   def close(_ref) do
     :erlang.nif_error(:nif_not_loaded)
   end
+
+  def info() do
+    :erlang.nif_error(:nif_not_loaded)
+  end
 end

--- a/src/hal_spidev.c
+++ b/src/hal_spidev.c
@@ -1,0 +1,100 @@
+/*
+ *  Copyright 2018 Frank Hunleth, Mark Sebald
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPI NIF implementation.
+ */
+
+#include "spi_nif.h"
+#include <linux/spi/spidev.h>
+
+#ifndef _IOC_SIZE_BITS
+// Include <asm/ioctl.h> manually on platforms that don't include it
+// from <sys/ioctl.h>.
+#include <asm/ioctl.h>
+#endif
+
+ERL_NIF_TERM hal_info(ErlNifEnv *env)
+{
+    ERL_NIF_TERM info = enif_make_new_map(env);
+    enif_make_map_put(env, info, enif_make_atom(env, "name"), enif_make_atom(env, "spidev"), &info);
+    return info;
+}
+
+int hal_spi_open(const char *device,
+                 const struct SpiConfig *config,
+                 char *error_str)
+{
+    char devpath[64] = "/dev/";
+
+    strcat(devpath, device);
+    int fd = open(devpath, O_RDWR);
+    if (fd < 0) {
+        strcpy(error_str, "access_denied");
+        return -1;
+    }
+
+    // Set these to check for bad values given by the user. They get
+    // set again on each transfer.
+    uint8_t mode = (uint8_t) config->mode;
+    if (ioctl(fd, SPI_IOC_WR_MODE, &mode) < 0) {
+        strcpy(error_str, "invalid_mode");
+        return -1;
+    }
+
+    uint8_t bits_per_word = (uint8_t) config->bits_per_word;
+    if (ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, &bits_per_word) < 0) {
+        strcpy(error_str, "invalid_bits_per_word");
+        return -1;
+    }
+
+    uint32_t speed_hz = config->speed_hz;
+    if (ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed_hz) < 0) {
+        strcpy(error_str, "invalid_speed");
+        return -1;
+    }
+
+    return fd;
+}
+
+
+void hal_spi_close(int fd)
+{
+    close(fd);
+}
+
+int hal_spi_transfer(int fd,
+                     const struct SpiConfig *config,
+                     const uint8_t *to_write,
+                     uint8_t *to_read,
+                     size_t len)
+{
+    struct spi_ioc_transfer tfer;
+
+    memset(&tfer, 0, sizeof(tfer));
+    tfer.speed_hz = config->speed_hz;
+    tfer.delay_usecs = (uint16_t ) config->delay_us;
+    tfer.bits_per_word = (uint8_t) config->bits_per_word;
+
+    // The Linux header spidev.h expects pointers to be in 64-bit integers (__u64),
+    // but pointers on Raspberry Pi are only 32 bits.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpointer-to-int-cast"
+    tfer.tx_buf = (__u64) to_write;
+    tfer.rx_buf = (__u64) to_read;
+#pragma GCC diagnostic pop
+    tfer.len = (uint32_t) len;
+
+    return ioctl(fd, SPI_IOC_MESSAGE(1), &tfer);
+}

--- a/src/hal_stub.c
+++ b/src/hal_stub.c
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2018 Frank Hunleth, Mark Sebald
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPI NIF implementation.
+ */
+
+#include "spi_nif.h"
+#include <string.h>
+
+ERL_NIF_TERM hal_info(ErlNifEnv *env)
+{
+    ERL_NIF_TERM info = enif_make_new_map(env);
+    enif_make_map_put(env, info, enif_make_atom(env, "name"), enif_make_atom(env, "stub"), &info);
+    return info;
+}
+
+int hal_spi_open(const char *device,
+                 const struct SpiConfig *config,
+                 char *error_str)
+{
+    *error_str = '\0';
+    return 0;
+}
+
+void hal_spi_close(int fd)
+{
+}
+
+int hal_spi_transfer(int fd,
+                     const struct SpiConfig *config,
+                     const uint8_t *to_write,
+                     uint8_t *to_read,
+                     size_t len)
+{
+    // Loop back.
+    memcpy(to_read, to_write, len);
+
+    return 0;
+}

--- a/test/circuits_spi_test.exs
+++ b/test/circuits_spi_test.exs
@@ -1,0 +1,10 @@
+defmodule CircuitsSPITest do
+  use ExUnit.Case
+
+  test "info returns a map" do
+    info = Circuits.SPI.info()
+
+    assert is_map(info)
+    assert Map.has_key?(info, :name)
+  end
+end


### PR DESCRIPTION
The immediate advantage to this is that it enables compilation and the
ability to exercise the NIF on OSX.