### PR TITLE
Naming and specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,12 @@ jobs:
       - run: mix format --check-formatted
       - run: mix test
       - run: mix docs
+      - run: mix dialyzer --halt-exit-status
+      - save_cache:
+          key: v1-dependency-cache-{{ checksum "mix.lock" }}
+          paths:
+            - _build
+            - deps
 
   build_elixir_1_6_otp_21:
     docker:

--- a/Makefile
+++ b/Makefile
@@ -15,50 +15,40 @@ NIF=priv/spi_nif.so
 ifeq ($(CROSSCOMPILE),)
     # Not crosscompiling, so check that we're on Linux.
     ifneq ($(shell uname -s),Linux)
-        $(warning Elixir Circuits only works on Linux, but crosscompilation)
-        $(warning is supported by defining $$CROSSCOMPILE, $$ERL_EI_INCLUDE_DIR,)
-        $(warning and $$ERL_EI_LIBDIR. See Makefile for details. If using Nerves,)
-        $(warning this should be done automatically.)
-        $(warning .)
-        $(warning Skipping C compilation unless targets explicitly passed to make.)
-	DEFAULT_TARGETS = priv
+        $(warning Elixir Circuits only works on Nerves and Linux platforms.)
+        $(warning A stub NIF will be compiled for test purposes.)
+	HAL = src/hal_stub.c
+        LDFLAGS += -undefined dynamic_lookup -dynamiclib
+    else
+        LDFLAGS += -fPIC -shared
     endif
+else
+# Crosscompiled build
+LDFLAGS += -fPIC -shared
 endif
-DEFAULT_TARGETS ?= priv $(NIF)
+HAL ?= src/hal_spidev.c
 
-# Look for the EI library and header files
-# For crosscompiled builds, ERL_EI_INCLUDE_DIR and ERL_EI_LIBDIR must be
-# passed into the Makefile.
-ifeq ($(ERL_EI_INCLUDE_DIR),)
-ERL_ROOT_DIR = $(shell erl -eval "io:format(\"~s~n\", [code:root_dir()])" -s init stop -noshell)
-ifeq ($(ERL_ROOT_DIR),)
-   $(error Could not find the Erlang installation. Check to see that 'erl' is in your PATH)
-endif
-ERL_EI_INCLUDE_DIR = "$(ERL_ROOT_DIR)/usr/include"
-ERL_EI_LIBDIR = "$(ERL_ROOT_DIR)/usr/lib"
-endif
+CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
 
 # Set Erlang-specific compile and linker flags
 ERL_CFLAGS ?= -I$(ERL_EI_INCLUDE_DIR)
-ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR) -lei
+ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR)
 
-LDFLAGS += -fPIC -shared -pedantic
-CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter
-
-SRC=$(wildcard src/*.c)
+SRC =src/spi_nif.c $(HAL)
+HEADERS =$(wildcard src/*.h)
 
 calling_from_make:
 	mix compile
 
-all: $(DEFAULT_TARGETS)
-
-$(NIF): $(wildcard src/*.h)
+all: priv $(NIF)
 
 priv:
 	mkdir -p priv
 
+$(NIF): $(HEADERS)
+
 $(NIF): $(SRC)
-	$(CC) $(ERL_CFLAGS) $(CFLAGS) $(ERL_LDFLAGS) $(LDFLAGS) -o $@ $^
+	$(CC) -o $@ $(SRC) $(ERL_CFLAGS) $(CFLAGS) $(ERL_LDFLAGS) $(LDFLAGS)
 
 clean:
 	$(RM) $(NIF)

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The most common issue is communicating with a SPI device for the first time.  Fo
 first check that a SPI bus is available:
 
 ```elixir
-iex> Circuits.SPI.device_names
+iex> Circuits.SPI.bus_names()
 ["spidev0.0", "spidev0.1"]
 ```
 If the list is empty, then SPI is either not available, not enabled, or not

--- a/README.md
+++ b/README.md
@@ -89,26 +89,28 @@ and by running `h <<>>` at the IEx prompt.
 
 ### How do I debug?
 
-The most common issue is communicating with a SPI device for the first time.  For SPI,
-first check that a SPI bus is available:
+The most common issue is communicating with a SPI device for the first time.
+First check that a SPI bus is available:
 
 ```elixir
 iex> Circuits.SPI.bus_names()
 ["spidev0.0", "spidev0.1"]
 ```
-If the list is empty, then SPI is either not available, not enabled, or not
-configured in the kernel. If you're using Raspbian, run `raspi-config` and check
-that SPI is enabled in the advanced options. If you're on a BeagleBone, try
-running `config-pin` and see the [Universal I/O
+
+If the list is empty, then a SPI bus is either not available, not enabled, or
+not configured in the kernel. If you're using Raspbian, run `raspi-config` and
+check that SPI is enabled in the advanced options. If you're on a BeagleBone,
+try running `config-pin` and see the [Universal I/O
 project](https://github.com/cdsteinkuehler/beaglebone-universal-io) to enable
 the SPI pins. On other ARM boards, double check that SPI is enabled in the
 kernel and that the device tree configures it.
 
 ### Where can I get help?
 
-The hardest part is communicating with a device for the first time. The issue is
-usually unrelated to `Circuits.SPI`. If you expand your searches to
-include Python and C forums, you'll frequently find the answer.
+Many issues are unrelated to `Circuits.SPI`. If you expand your searches to
+include Python and C forums, it's possible that someone else has run into your
+problem too. SPI libraries in other languages should be similar to
+`Circuits.SPI` so hopefully you'll find the answer.
 
 If that fails, try posting a question to the [Elixir
 Forum](https://elixirforum.com/). Tag the question with `Nerves` and it will
@@ -135,8 +137,10 @@ Arduino's Firmata protocol.
 
 ### How do I call Circuits.SPI from Erlang?
 
-An Erlang friendly binding has been provided to simplify syntax when calling `Circuits.SPI` functions from Erlang code.  Instead of prefixing calls with: `'Elixir.Circuits.SPI':` you may use the binding: `circuits_spi:`.
-For example: `circuits_spi:open("spidev0.1")`.
+An Erlang friendly binding has been provided to simplify syntax when calling
+`Circuits.SPI` functions from Erlang code.  Instead of prefixing calls with:
+`'Elixir.Circuits.SPI':` you may use the binding: `circuits_spi:`.  For example:
+`circuits_spi:open("spidev0.1")`.
 
 ## License
 

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -4,13 +4,23 @@ defmodule Circuits.SPI do
   via a SPI bus.
   """
 
-  alias Circuits.SPI.Nif, as: Nif
+  alias Circuits.SPI.Nif
 
+  @typedoc """
+  SPI bus options. See `open/2`.
+  """
   @type spi_option ::
           {:mode, 0..3}
           | {:bits_per_word, 0..16}
-          | {:speed_hz, pos_integer}
-          | {:delay_us, non_neg_integer}
+          | {:speed_hz, pos_integer()}
+          | {:delay_us, non_neg_integer()}
+
+  @typedoc """
+  SPI bus
+
+  Call `open/2` to obtain an SPI bus reference.
+  """
+  @type spi_bus() :: reference()
 
   @doc """
   Open SPI channel
@@ -27,7 +37,7 @@ defmodule Circuits.SPI do
   * `speed_hz`: bus speed (1000000)
   * `delay_us`: delay between transaction (10)
   """
-  @spec open(binary() | charlist(), [spi_option()]) :: {:ok, reference}
+  @spec open(binary() | charlist(), [spi_option()]) :: {:ok, spi_bus()}
   def open(bus_name, opts \\ []) do
     mode = Keyword.get(opts, :mode, 0)
     bits_per_word = Keyword.get(opts, :bits_per_word, 8)
@@ -41,17 +51,17 @@ defmodule Circuits.SPI do
   send. Since SPI transfers simultaneously send and receive, the return value
   will be a binary of the same length or an error.
   """
-  @spec transfer(reference, binary) :: {:ok, binary} | {:error, term}
-  def transfer(ref, data) do
-    Nif.transfer(ref, data)
+  @spec transfer(spi_bus(), binary()) :: {:ok, binary()} | {:error, term()}
+  def transfer(spi_bus, data) do
+    Nif.transfer(spi_bus, data)
   end
 
   @doc """
   Release any resources associated with the given file descriptor
   """
-  @spec close(reference) :: :ok
-  def close(ref) do
-    Nif.close(ref)
+  @spec close(spi_bus()) :: :ok
+  def close(spi_bus) do
+    Nif.close(spi_bus)
   end
 
   @doc """

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -15,11 +15,11 @@ defmodule Circuits.SPI do
   @doc """
   Open SPI channel
   On success, returns a reference.
-  Use reference in subsequent calls to transfer spi bus data
+  Use reference in subsequent calls to transfer SPI bus data
 
   Parameters:
-  * `device` is the Linux device name for the bus (e.g., "spidev0.0")
-  * `spi_opts` is a keyword list to configure the bus
+  * `bus_name` is the name of the bus (e.g., "spidev0.0")
+  * `opts` is a keyword list to configure the bus
 
   SPI bus options include:
   * `mode`: This specifies the clock polarity and phase to use. (0)
@@ -27,13 +27,13 @@ defmodule Circuits.SPI do
   * `speed_hz`: bus speed (1000000)
   * `delay_us`: delay between transaction (10)
   """
-  @spec open(binary, [spi_option]) :: {:ok, reference}
-  def open(device, spi_opts \\ []) do
-    mode = Keyword.get(spi_opts, :mode, 0)
-    bits_per_word = Keyword.get(spi_opts, :bits_per_word, 8)
-    speed_hz = Keyword.get(spi_opts, :speed_hz, 1_000_000)
-    delay_us = Keyword.get(spi_opts, :delay_us, 10)
-    Nif.open(to_charlist(device), mode, bits_per_word, speed_hz, delay_us)
+  @spec open(binary() | charlist(), [spi_option()]) :: {:ok, reference}
+  def open(bus_name, opts \\ []) do
+    mode = Keyword.get(opts, :mode, 0)
+    bits_per_word = Keyword.get(opts, :bits_per_word, 8)
+    speed_hz = Keyword.get(opts, :speed_hz, 1_000_000)
+    delay_us = Keyword.get(opts, :delay_us, 10)
+    Nif.open(to_charlist(bus_name), mode, bits_per_word, speed_hz, delay_us)
   end
 
   @doc """
@@ -55,17 +55,17 @@ defmodule Circuits.SPI do
   end
 
   @doc """
-  Return a list of available SPI bus device names.  If nothing is returned,
+  Return a list of available SPI bus names.  If nothing is returned,
   it's possible that the kernel driver for that SPI bus is not enabled or the
   kernel's device tree is not configured. On Raspbian, run `raspi-config` and
   look in the advanced options.
   ```
-  iex> Circuits.SPI.device_names
+  iex> Circuits.SPI.bus_names
   ["spidev0.0", "spidev0.1"]
   ```
   """
-  @spec device_names() :: [binary]
-  def device_names() do
+  @spec bus_names() :: [binary()]
+  def bus_names() do
     Path.wildcard("/dev/spidev*")
     |> Enum.map(fn p -> String.replace_prefix(p, "/dev/", "") end)
   end
@@ -83,8 +83,8 @@ defmodule Circuits.SPI do
     Provide an Erlang friendly interface to Circuits
     Example Erlang code:  circuits_spi:open("spidev0.1")
     """
-    defdelegate open(device), to: Circuits.SPI
-    defdelegate open(device, spi_opts), to: Circuits.SPI
+    defdelegate open(bus_name), to: Circuits.SPI
+    defdelegate open(bus_name, spi_opts), to: Circuits.SPI
     defdelegate transfer(ref, data), to: Circuits.SPI
     defdelegate close(ref), to: Circuits.SPI
   end

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -70,6 +70,14 @@ defmodule Circuits.SPI do
     |> Enum.map(fn p -> String.replace_prefix(p, "/dev/", "") end)
   end
 
+  @doc """
+  Return info about the low level SPI interface
+
+  This may be helpful when debugging SPI issues.
+  """
+  @spec info() :: map()
+  defdelegate info(), to: Nif
+
   defmodule :circuits_spi do
     @moduledoc """
     Provide an Erlang friendly interface to Circuits

--- a/lib/spi/spi_nif.ex
+++ b/lib/spi/spi_nif.ex
@@ -20,4 +20,8 @@ defmodule Circuits.SPI.Nif do
   def close(_ref) do
     :erlang.nif_error(:nif_not_loaded)
   end
+
+  def info() do
+    :erlang.nif_error(:nif_not_loaded)
+  end
 end

--- a/lib/spi/spi_nif.ex
+++ b/lib/spi/spi_nif.ex
@@ -9,7 +9,7 @@ defmodule Circuits.SPI.Nif do
     :erlang.load_nif(to_charlist(nif_binary), 0)
   end
 
-  def open(_device, _mode, _bits_per_word, _speed_hz, _delay_us) do
+  def open(_bus_name, _mode, _bits_per_word, _speed_hz, _delay_us) do
     :erlang.nif_error(:nif_not_loaded)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,8 @@ defmodule Circuits.SPI.MixProject do
   defp deps do
     [
       {:elixir_make, "~> 0.4", runtime: false},
-      {:ex_doc, "~> 0.11", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.11", only: :dev, runtime: false},
+      {:dialyxir, "1.0.0-rc.4", only: :dev, runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,8 @@
 %{
+  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.4", "71b42f5ee1b7628f3e3a6565f4617dfb02d127a0499ab3e72750455e986df001", [:mix], [{:erlex, "~> 0.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
+  "erlex": {:hex, :erlex, "0.1.6", "c01c889363168d3fdd23f4211647d8a34c0f9a21ec726762312e08e083f3d47e", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},

--- a/src/hal_spidev.c
+++ b/src/hal_spidev.c
@@ -1,0 +1,100 @@
+/*
+ *  Copyright 2018 Frank Hunleth, Mark Sebald
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPI NIF implementation.
+ */
+
+#include "spi_nif.h"
+#include <linux/spi/spidev.h>
+
+#ifndef _IOC_SIZE_BITS
+// Include <asm/ioctl.h> manually on platforms that don't include it
+// from <sys/ioctl.h>.
+#include <asm/ioctl.h>
+#endif
+
+ERL_NIF_TERM hal_info(ErlNifEnv *env)
+{
+    ERL_NIF_TERM info = enif_make_new_map(env);
+    enif_make_map_put(env, info, enif_make_atom(env, "name"), enif_make_atom(env, "spidev"), &info);
+    return info;
+}
+
+int hal_spi_open(const char *device,
+                 const struct SpiConfig *config,
+                 char *error_str)
+{
+    char devpath[64] = "/dev/";
+
+    strcat(devpath, device);
+    int fd = open(devpath, O_RDWR);
+    if (fd < 0) {
+        strcpy(error_str, "access_denied");
+        return -1;
+    }
+
+    // Set these to check for bad values given by the user. They get
+    // set again on each transfer.
+    uint8_t mode = (uint8_t) config->mode;
+    if (ioctl(fd, SPI_IOC_WR_MODE, &mode) < 0) {
+        strcpy(error_str, "invalid_mode");
+        return -1;
+    }
+
+    uint8_t bits_per_word = (uint8_t) config->bits_per_word;
+    if (ioctl(fd, SPI_IOC_WR_BITS_PER_WORD, &bits_per_word) < 0) {
+        strcpy(error_str, "invalid_bits_per_word");
+        return -1;
+    }
+
+    uint32_t speed_hz = config->speed_hz;
+    if (ioctl(fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed_hz) < 0) {
+        strcpy(error_str, "invalid_speed");
+        return -1;
+    }
+
+    return fd;
+}
+
+
+void hal_spi_close(int fd)
+{
+    close(fd);
+}
+
+int hal_spi_transfer(int fd,
+                     const struct SpiConfig *config,
+                     const uint8_t *to_write,
+                     uint8_t *to_read,
+                     size_t len)
+{
+    struct spi_ioc_transfer tfer;
+
+    memset(&tfer, 0, sizeof(tfer));
+    tfer.speed_hz = config->speed_hz;
+    tfer.delay_usecs = (uint16_t ) config->delay_us;
+    tfer.bits_per_word = (uint8_t) config->bits_per_word;
+
+    // The Linux header spidev.h expects pointers to be in 64-bit integers (__u64),
+    // but pointers on Raspberry Pi are only 32 bits.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpointer-to-int-cast"
+    tfer.tx_buf = (__u64) to_write;
+    tfer.rx_buf = (__u64) to_read;
+#pragma GCC diagnostic pop
+    tfer.len = (uint32_t) len;
+
+    return ioctl(fd, SPI_IOC_MESSAGE(1), &tfer);
+}

--- a/src/hal_stub.c
+++ b/src/hal_stub.c
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2018 Frank Hunleth, Mark Sebald
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPI NIF implementation.
+ */
+
+#include "spi_nif.h"
+#include <string.h>
+
+ERL_NIF_TERM hal_info(ErlNifEnv *env)
+{
+    ERL_NIF_TERM info = enif_make_new_map(env);
+    enif_make_map_put(env, info, enif_make_atom(env, "name"), enif_make_atom(env, "stub"), &info);
+    return info;
+}
+
+int hal_spi_open(const char *device,
+                 const struct SpiConfig *config,
+                 char *error_str)
+{
+    *error_str = '\0';
+    return 0;
+}
+
+void hal_spi_close(int fd)
+{
+}
+
+int hal_spi_transfer(int fd,
+                     const struct SpiConfig *config,
+                     const uint8_t *to_write,
+                     uint8_t *to_read,
+                     size_t len)
+{
+    // Loop back.
+    memcpy(to_read, to_write, len);
+
+    return 0;
+}

--- a/test/circuits_spi_test.exs
+++ b/test/circuits_spi_test.exs
@@ -1,0 +1,10 @@
+defmodule CircuitsSPITest do
+  use ExUnit.Case
+
+  test "info returns a map" do
+    info = Circuits.SPI.info()
+
+    assert is_map(info)
+    assert Map.has_key?(info, :name)
+  end
+end


### PR DESCRIPTION
This renames `device_names` to `bus_names` to be consistent with I2C naming. It also pulls in the Dialyzer and spec updates from I2C.

The idea is to merge this PR after #11.