### PR TITLE
Use separate build directories for C compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,11 @@ defaults: &defaults
   working_directory: ~/repo
 
 jobs:
-  build_elixir_1_7_otp_21:
+  build_elixir_1_8_otp_21:
     docker:
-      - image: erlang:21.1
+      - image: erlang:21.2
         environment:
-          ELIXIR_VERSION: 1.7.3-otp-21
+          ELIXIR_VERSION: 1.8.1-otp-21
           LC_ALL: C.UTF-8
     <<: *defaults
     steps:
@@ -38,16 +38,38 @@ jobs:
       - <<: *install_system_deps
       - <<: *install_elixir
       - <<: *install_hex_rebar
+      - restore_cache:
+          keys:
+            - v1-mix-cache-{{ checksum "mix.lock" }}
       - run: mix deps.get
       - run: mix format --check-formatted
+      - run: mix hex.build
+      - run: mix compile
       - run: mix test
       - run: mix docs
       - run: mix dialyzer --halt-exit-status
       - save_cache:
-          key: v1-dependency-cache-{{ checksum "mix.lock" }}
+          key: v1-mix-cache-{{ checksum "mix.lock" }}
           paths:
             - _build
             - deps
+
+  build_elixir_1_7_otp_21:
+    docker:
+      - image: erlang:21.1
+        environment:
+          ELIXIR_VERSION: 1.7.4-otp-21
+          LC_ALL: C.UTF-8
+          SUDO: true
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_system_deps
+      - <<: *install_elixir
+      - <<: *install_hex_rebar
+      - run: mix deps.get
+      - run: mix compile
+      - run: mix test
 
   build_elixir_1_6_otp_21:
     docker:
@@ -63,6 +85,7 @@ jobs:
       - <<: *install_elixir
       - <<: *install_hex_rebar
       - run: mix deps.get
+      - run: mix compile
       - run: mix test
 
   build_elixir_1_6_otp_20:
@@ -79,12 +102,14 @@ jobs:
       - <<: *install_elixir
       - <<: *install_hex_rebar
       - run: mix deps.get
+      - run: mix compile
       - run: mix test
 
 workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_8_otp_21
       - build_elixir_1_7_otp_21
       - build_elixir_1_6_otp_21
       - build_elixir_1_6_otp_20

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
-# Variables to override
+# Makefile for building the NIF
+#
+# Makefile targets:
+#
+# all/install   build and install the NIF
+# clean         clean build products and intermediates
+#
+# Variables to override:
+#
+# BUILD         where to store intermediate files (defaults to src directory)
+# PREFIX        path to the installation direction (defaults to ./priv)
 #
 # CC            C compiler
 # CROSSCOMPILE	crosscompiler prefix, if any
@@ -9,7 +19,12 @@
 # LDFLAGS	linker flags for linking all binaries
 # ERL_LDFLAGS	additional linker flags for projects referencing Erlang libraries
 
-NIF=priv/spi_nif.so
+PREFIX ?= priv
+BUILD ?= src
+
+NIF = $(PREFIX)/spi_nif.so
+
+CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
 
 # Check that we're on a supported build platform
 ifeq ($(CROSSCOMPILE),)
@@ -17,40 +32,48 @@ ifeq ($(CROSSCOMPILE),)
     ifneq ($(shell uname -s),Linux)
         $(warning Elixir Circuits only works on Nerves and Linux platforms.)
         $(warning A stub NIF will be compiled for test purposes.)
-	HAL = src/hal_stub.c
+	HAL_SRC = src/hal_stub.c
         LDFLAGS += -undefined dynamic_lookup -dynamiclib
     else
         LDFLAGS += -fPIC -shared
+        CFLAGS += -fPIC
     endif
 else
 # Crosscompiled build
 LDFLAGS += -fPIC -shared
 endif
-HAL ?= src/hal_spidev.c
-
-CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
 
 # Set Erlang-specific compile and linker flags
 ERL_CFLAGS ?= -I$(ERL_EI_INCLUDE_DIR)
-ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR)
+ERL_LDFLAGS ?= -L$(ERL_EI_LIBDIR) -lei
 
-SRC =src/spi_nif.c $(HAL)
+HAL_SRC ?= src/hal_spidev.c
+SRC = $(HAL_SRC) src/spi_nif.c
 HEADERS =$(wildcard src/*.h)
+OBJ = $(SRC:src/%.c=$(BUILD)/%.o)
 
 calling_from_make:
 	mix compile
 
-all: priv $(NIF)
+all: install
 
-priv:
-	mkdir -p priv
+install: $(PREFIX) $(BUILD) $(NIF)
 
-$(NIF): $(HEADERS)
+$(OBJ): $(HEADERS) Makefile
 
-$(NIF): $(SRC)
-	$(CC) -o $@ $(SRC) $(ERL_CFLAGS) $(CFLAGS) $(ERL_LDFLAGS) $(LDFLAGS)
+$(BUILD)/%.o: src/%.c
+	$(CC) -c $(ERL_CFLAGS) $(CFLAGS) -o $@ $<
+
+$(NIF): $(OBJ)
+	$(CC) -o $@ $(ERL_LDFLAGS) $(LDFLAGS) $^
+
+$(PREFIX):
+	mkdir -p $@
+
+$(BUILD):
+	mkdir -p $@
 
 clean:
-	$(RM) $(NIF)
+	$(RM) $(NIF) $(BUILD)/*.o
 
-.PHONY: all clean calling_from_make
+.PHONY: all clean calling_from_make install

--- a/mix.exs
+++ b/mix.exs
@@ -12,18 +12,46 @@ defmodule Circuits.SPI.MixProject do
       compilers: [:elixir_make | Mix.compilers()],
       make_targets: ["all"],
       make_clean: ["clean"],
-      make_env: make_env(),
-      docs: [extras: ["README.md","PORTING.md"], main: "readme"],
+      make_env: &make_env/0,
+      docs: [extras: ["README.md", "PORTING.md"], main: "readme"],
       aliases: [docs: ["docs", &copy_images/1], format: ["format", &format_c/1]],
       start_permanent: Mix.env() == :prod,
+      build_embedded: true,
       deps: deps()
     ]
+  end
+
+  defp make_env() do
+    base =
+      Mix.Project.compile_path()
+      |> Path.join("..")
+      |> Path.expand()
+
+    %{
+      "MIX_ENV" => to_string(Mix.env()),
+      "PREFIX" => Path.join(base, "priv"),
+      "BUILD" => Path.join(base, "obj")
+    }
+    |> Map.merge(ei_env())
+  end
+
+  defp ei_env() do
+    case System.get_env("ERL_EI_INCLUDE_DIR") do
+      nil ->
+        %{
+          "ERL_EI_INCLUDE_DIR" => "#{:code.root_dir()}/usr/include",
+          "ERL_EI_LIBDIR" => "#{:code.root_dir()}/usr/lib"
+        }
+
+      _ ->
+        %{}
+    end
   end
 
   def application, do: []
 
   defp description do
-    "Elixir access to the hardware SPI interfaces"
+    "Use SPI in Elixir"
   end
 
   defp package do
@@ -33,6 +61,7 @@ defmodule Circuits.SPI.MixProject do
         "src/*.[ch]",
         "mix.exs",
         "README.md",
+        "PORTING.md",
         "LICENSE",
         "Makefile"
       ],
@@ -65,17 +94,4 @@ defmodule Circuits.SPI.MixProject do
   end
 
   defp format_c(_args), do: true
-
-  defp make_env() do
-    case System.get_env("ERL_EI_INCLUDE_DIR") do
-      nil ->
-        %{
-          "ERL_EI_INCLUDE_DIR" => "#{:code.root_dir()}/usr/include",
-          "ERL_EI_LIBDIR" => "#{:code.root_dir()}/usr/lib"
-        }
-
-      _ ->
-        %{}
-    end
-  end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
 %{
   "dialyxir": {:hex, :dialyxir, "1.0.0-rc.4", "71b42f5ee1b7628f3e3a6565f4617dfb02d127a0499ab3e72750455e986df001", [:mix], [{:erlex, "~> 0.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.6", "b6da42b3831458d3ecc57314dff3051b080b9b2be88c2e5aa41cd642a5b044ed", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
-  "erlex": {:hex, :erlex, "0.1.6", "c01c889363168d3fdd23f4211647d8a34c0f9a21ec726762312e08e083f3d47e", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
+  "erlex": {:hex, :erlex, "0.2.0", "80349ebd58553dbd63489937380bfa7d906be3266b91bbd9d2bd6b71f1e8c07d", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
This PR pulls in a set of changes from circuits_gpio to fix the issue where you switch MIX_TARGETs and the C source isn't recompiled.