### PR TITLE
 Properly allocated binaries in NIF 

### DIFF
--- a/src/spi_nif.c
+++ b/src/spi_nif.c
@@ -85,6 +85,7 @@ static ERL_NIF_TERM spi_open(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]
     struct SpiConfig config;
     int fd;
 
+    debug("spi_open");
     if (!enif_get_string(env, argv[0], device, sizeof(device), ERL_NIF_LATIN1))
         return enif_make_badarg(env);
 
@@ -126,6 +127,7 @@ static ERL_NIF_TERM spi_transfer(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
     ErlNifBinary bin_read;
     uint8_t read_data[SPI_TRANSFER_MAX];
 
+    debug("spi_transfer");
     if (!enif_get_resource(env, argv[0], priv->spi_nif_res_type, (void **)&res))
         return enif_make_badarg(env);
 
@@ -146,6 +148,7 @@ static ERL_NIF_TERM spi_close(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[
 {
     struct SpiNifPriv *priv = enif_priv_data(env);
     struct SpiNifRes *res;
+    debug("spi_close");
 
     if (!enif_get_resource(env, argv[0], priv->spi_nif_res_type, (void **)&res))
         return enif_make_badarg(env);

--- a/src/spi_nif.h
+++ b/src/spi_nif.h
@@ -30,9 +30,6 @@
 #define elapsed_microseconds() 0
 #endif
 
-// Max SPI transfer size that we support
-#define SPI_TRANSFER_MAX 4096
-
 struct SpiConfig {
     unsigned int mode;
     unsigned int bits_per_word;


### PR DESCRIPTION
ErlNifBinary was being directly set even though this is not allowed.
This updates the code to properly allocate the binary. This fixes a
segfault on Raspbian (and most likely everywhere else)

Fixes #23