### PR TITLE
Support older Elixir versions/make astyle optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ install_system_deps: &install_system_deps
     name: Install system dependencies
     command: |
       apt update
-      apt install -y unzip astyle
+      apt install -y unzip
 
 defaults: &defaults
   working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ defaults: &defaults
 jobs:
   build_elixir_1_8_otp_21:
     docker:
-      - image: erlang:21.2
+      - image: erlang:21.3
         environment:
           ELIXIR_VERSION: 1.8.1-otp-21
           LC_ALL: C.UTF-8
@@ -43,10 +43,10 @@ jobs:
             - v1-mix-cache-{{ checksum "mix.lock" }}
       - run: mix deps.get
       - run: mix format --check-formatted
-      - run: mix hex.build
       - run: mix compile
-      - run: mix test
       - run: mix docs
+      - run: mix hex.build
+      - run: mix test
       - run: mix dialyzer --halt-exit-status
       - save_cache:
           key: v1-mix-cache-{{ checksum "mix.lock" }}
@@ -56,28 +56,10 @@ jobs:
 
   build_elixir_1_7_otp_21:
     docker:
-      - image: erlang:21.1
+      - image: erlang:21.3
         environment:
           ELIXIR_VERSION: 1.7.4-otp-21
           LC_ALL: C.UTF-8
-          SUDO: true
-    <<: *defaults
-    steps:
-      - checkout
-      - <<: *install_system_deps
-      - <<: *install_elixir
-      - <<: *install_hex_rebar
-      - run: mix deps.get
-      - run: mix compile
-      - run: mix test
-
-  build_elixir_1_6_otp_21:
-    docker:
-      - image: erlang:21.1
-        environment:
-          ELIXIR_VERSION: 1.6.6-otp-21
-          LC_ALL: C.UTF-8
-          SUDO: true
     <<: *defaults
     steps:
       - checkout
@@ -92,9 +74,8 @@ jobs:
     docker:
       - image: erlang:20.3.8
         environment:
-          ELIXIR_VERSION: 1.6.6
+          ELIXIR_VERSION: 1.6.6-otp-20
           LC_ALL: C.UTF-8
-          SUDO: true
     <<: *defaults
     steps:
       - checkout
@@ -105,11 +86,46 @@ jobs:
       - run: mix compile
       - run: mix test
 
+  build_elixir_1_5_otp_20:
+    docker:
+      - image: erlang:20.3.8
+        environment:
+          ELIXIR_VERSION: 1.5.3-otp-20
+          LC_ALL: C.UTF-8
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_system_deps
+      - <<: *install_elixir
+      - <<: *install_hex_rebar
+      - run: mix deps.get
+      - run: mix compile
+      - run: MIX_ENV=test mix compile
+      - run: mix test
+
+  build_elixir_1_4_otp_20:
+    docker:
+      - image: erlang:20.3.8
+        environment:
+          ELIXIR_VERSION: 1.4.5-otp-20
+          LC_ALL: C.UTF-8
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_system_deps
+      - <<: *install_elixir
+      - <<: *install_hex_rebar
+      - run: mix deps.get
+      - run: mix compile
+      - run: MIX_ENV=test mix compile
+      - run: mix test
+
 workflows:
   version: 2
   build_test:
     jobs:
       - build_elixir_1_8_otp_21
       - build_elixir_1_7_otp_21
-      - build_elixir_1_6_otp_21
       - build_elixir_1_6_otp_20
+      - build_elixir_1_5_otp_20
+      - build_elixir_1_4_otp_20

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Circuits.SPI.MixProject do
       make_targets: ["all"],
       make_clean: ["clean"],
       docs: [extras: ["README.md", "PORTING.md"], main: "readme"],
-      aliases: [docs: ["docs", &copy_images/1], format: ["format", &format_c/1]],
+      aliases: [docs: ["docs", &copy_images/1], format: [&format_c/1, "format"]],
       start_permanent: Mix.env() == :prod,
       build_embedded: true,
       dialyzer: [
@@ -59,13 +59,13 @@ defmodule Circuits.SPI.MixProject do
   end
 
   defp format_c([]) do
-    astyle =
-      System.find_executable("astyle") ||
-        Mix.raise("""
-        Could not format C code since astyle is not available.
-        """)
+    case System.find_executable("astyle") do
+      nil ->
+        Mix.Shell.IO.info("Install astyle to format C code.")
 
-    System.cmd(astyle, ["-n", "src/*.c", "src/*.h"], into: IO.stream(:stdio, :line))
+      astyle ->
+        System.cmd(astyle, ["-n", "src/*.c"], into: IO.stream(:stdio, :line))
+    end
   end
 
   defp format_c(_args), do: true

--- a/mix.exs
+++ b/mix.exs
@@ -1,11 +1,14 @@
 defmodule Circuits.SPI.MixProject do
   use Mix.Project
 
+  {:ok, system_version} = Version.parse(System.version())
+  @elixir_version {system_version.major, system_version.minor, system_version.patch}
+
   def project do
     [
       app: :circuits_spi,
       version: "0.1.3",
-      elixir: "~> 1.6",
+      elixir: "~> 1.4",
       description: description(),
       package: package(),
       source_url: "https://github.com/elixir-circuits/circuits_spi",
@@ -19,7 +22,7 @@ defmodule Circuits.SPI.MixProject do
       dialyzer: [
         flags: [:unmatched_returns, :error_handling, :race_conditions, :underspecs]
       ],
-      deps: deps()
+      deps: deps(@elixir_version)
     ]
   end
 
@@ -45,11 +48,19 @@ defmodule Circuits.SPI.MixProject do
     }
   end
 
-  defp deps do
+  defp deps(elixir_version) when elixir_version >= {1, 7, 0} do
     [
-      {:elixir_make, "~> 0.5", runtime: false},
       {:ex_doc, "~> 0.11", only: :dev, runtime: false},
-      {:dialyxir, "1.0.0-rc.4", only: :dev, runtime: false}
+      {:dialyxir, "~> 1.0.0-rc.6", only: :dev, runtime: false}
+      | deps()
+    ]
+  end
+
+  defp deps(_), do: deps()
+
+  defp deps() do
+    [
+      {:elixir_make, "~> 0.5", runtime: false}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.4", "71b42f5ee1b7628f3e3a6565f4617dfb02d127a0499ab3e72750455e986df001", [:mix], [{:erlex, "~> 0.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "1.0.0-rc.6", "78e97d9c0ff1b5521dd68041193891aebebce52fc3b93463c0a6806874557d7d", [:mix], [{:erlex, "~> 0.2.1", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.5.1", "cee27c69bddcd6e333a24f2313786d1c9a970c49fcf700ecf1f7246f3a210f39", [:mix], [], "hexpm"},
   "erlex": {:hex, :erlex, "0.2.1", "cee02918660807cbba9a7229cae9b42d1c6143b768c781fa6cee1eaf03ad860b", [:mix], [], "hexpm"},


### PR DESCRIPTION
I was attempting to get Elixir Circuits to work on Raspbian Stretch using the default Elixir and Erlang versions supplied by the Raspberry Pi Foundation. This PR doesn't get us there. Raspbian currently supports Erlang 19.1 and Elixir 1.3.3. Erlang 19.1 needs more works since we use dirty NIFs and Circuits.GPIO is even more involved in what needs to change for pre-OTP 20 Erlang. Elixir is less of an issue, but I quit with Elixir 1.4, since Elixir 1.3 seemed to expect OTP 19 (but I might have messed up). 

I feel like the work to make astyle optional, the CircleCI config cleanup, and support for Elixir 1.4 are reasonable to have going forward. 