### PR TITLE
Add badge and link to API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/elixir-circuits/circuits_spi.svg?style=svg)](https://circleci.com/gh/elixir-circuits/circuits_spi)
 [![Hex version](https://img.shields.io/hexpm/v/circuits_spi.svg "Hex version")](https://hex.pm/packages/circuits_spi)
+[![API docs](https://img.shields.io/hexpm/v/circuits_spi.svg?label=hexdocs "API docs")](https://hexdocs.pm/circuits_spi/Circuits.SPI.html)
 
 `Circuits.SPI` provides high level abstractions for interfacing to SPI buses on
 Linux platforms. Internally, it uses the [Linux device

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Circuits.SPI
 
-[![CircleCI](https://circleci.com/gh/elixir-circuits/circuits_spi.svg?style=svg)](https://circleci.com/gh/elixir-circuits/circuits_spi)
 [![Hex version](https://img.shields.io/hexpm/v/circuits_spi.svg "Hex version")](https://hex.pm/packages/circuits_spi)
 [![API docs](https://img.shields.io/hexpm/v/circuits_spi.svg?label=hexdocs "API docs")](https://hexdocs.pm/circuits_spi/Circuits.SPI.html)
+[![CircleCI](https://circleci.com/gh/elixir-circuits/circuits_spi.svg?style=svg)](https://circleci.com/gh/elixir-circuits/circuits_spi)
 
 `Circuits.SPI` provides high level abstractions for interfacing to SPI buses on
 Linux platforms. Internally, it uses the [Linux device


### PR DESCRIPTION
This also reorders the badges so that the hexpm ones are first. Those seem like the more important ones for most people finding this project.