### PR TITLE
Add `max_transfer_size/0`

### DIFF
--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -57,17 +57,6 @@ defmodule Circuits.SPI do
   end
 
   @doc """
-  Perform a SPI transfer. The `data` should be a binary containing the bytes to
-  send. The `chunk_size` specifies maximum number of bytes to be sent in a single
-  transfer. Since SPI transfers simultaneously send and receive, the return value
-  will be a binary of the same length or an error.
-  """
-  @spec transfer(spi_bus(), binary(), non_neg_integer()) :: {:ok, binary()} | {:error, term()}
-  def transfer(spi_bus, data, chunk_size) do
-    Nif.transfer(spi_bus, data, chunk_size)
-  end
-
-  @doc """
   Release any resources associated with the given file descriptor
   """
   @spec close(spi_bus()) :: :ok

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -100,8 +100,8 @@ defmodule Circuits.SPI do
   If you're sending large amounts of data over SPI, use this
   function to determine how to split up large messages.
   """
-  @spec max_buf_size() :: non_neg_integer()
-  defdelegate max_buf_size(), to: Nif
+  @spec max_transfer_size() :: non_neg_integer()
+  defdelegate max_transfer_size(), to: Nif
 
   defmodule :circuits_spi do
     @moduledoc """

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -122,7 +122,6 @@ defmodule Circuits.SPI do
     defdelegate open(bus_name), to: Circuits.SPI
     defdelegate open(bus_name, spi_opts), to: Circuits.SPI
     defdelegate transfer(ref, data), to: Circuits.SPI
-    defdelegate transfer(ref, data, chunk_size), to: Circuits.SPI
     defdelegate close(ref), to: Circuits.SPI
   end
 end

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -100,11 +100,18 @@ defmodule Circuits.SPI do
   defdelegate info(), to: Nif
 
   @doc """
-  Return max buffer size of the low level SPI interface
+  Return the maximum transfer size in bytes
 
-  This may be helpful when deciding transfer size.
+  The number of bytes that can be sent and received at a time
+  may be capped by the low level SPI interface. For example,
+  the Linux `spidev` driver allocates its transfer buffer at
+  initialization based on the `bufsiz` parameter and rejects
+  requests that won't fit.
+
+  If you're sending large amounts of data over SPI, use this
+  function to determine how to split up large messages.
   """
-  @spec max_buf_size() :: integer() | :unknown
+  @spec max_buf_size() :: non_neg_integer()
   defdelegate max_buf_size(), to: Nif
 
   defmodule :circuits_spi do

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -93,7 +93,7 @@ defmodule Circuits.SPI do
 
   This may be helpful when deciding transfer size.
   """
-  @spec max_buf_size() :: integer()
+  @spec max_buf_size() :: integer() | :unknown
   defdelegate max_buf_size(), to: Nif
 
   defmodule :circuits_spi do

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -53,7 +53,7 @@ defmodule Circuits.SPI do
   """
   @spec transfer(spi_bus(), binary()) :: {:ok, binary()} | {:error, term()}
   def transfer(spi_bus, data) do
-    Nif.transfer(spi_bus, data, nil)
+    Nif.transfer(spi_bus, data)
   end
 
   @doc """

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -88,6 +88,14 @@ defmodule Circuits.SPI do
   @spec info() :: map()
   defdelegate info(), to: Nif
 
+  @doc """
+  Return max buffer size of the low level SPI interface
+
+  This may be helpful when deciding transfer size.
+  """
+  @spec max_buf_size() :: integer()
+  defdelegate max_buf_size(), to: Nif
+
   defmodule :circuits_spi do
     @moduledoc """
     Provide an Erlang friendly interface to Circuits

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -53,7 +53,18 @@ defmodule Circuits.SPI do
   """
   @spec transfer(spi_bus(), binary()) :: {:ok, binary()} | {:error, term()}
   def transfer(spi_bus, data) do
-    Nif.transfer(spi_bus, data)
+    Nif.transfer(spi_bus, data, nil)
+  end
+
+  @doc """
+  Perform a SPI transfer. The `data` should be a binary containing the bytes to
+  send. The `chunk_size` specifies maximum number of bytes to be sent in a single
+  transfer. Since SPI transfers simultaneously send and receive, the return value
+  will be a binary of the same length or an error.
+  """
+  @spec transfer(spi_bus(), binary(), non_neg_integer()) :: {:ok, binary()} | {:error, term()}
+  def transfer(spi_bus, data, chunk_size) do
+    Nif.transfer(spi_bus, data, chunk_size)
   end
 
   @doc """
@@ -104,6 +115,7 @@ defmodule Circuits.SPI do
     defdelegate open(bus_name), to: Circuits.SPI
     defdelegate open(bus_name, spi_opts), to: Circuits.SPI
     defdelegate transfer(ref, data), to: Circuits.SPI
+    defdelegate transfer(ref, data, chunk_size), to: Circuits.SPI
     defdelegate close(ref), to: Circuits.SPI
   end
 end

--- a/lib/spi/spi_nif.ex
+++ b/lib/spi/spi_nif.ex
@@ -24,4 +24,8 @@ defmodule Circuits.SPI.Nif do
   def info() do
     :erlang.nif_error(:nif_not_loaded)
   end
+
+  def max_buf_size() do
+    :erlang.nif_error(:nif_not_loaded)
+  end
 end

--- a/lib/spi/spi_nif.ex
+++ b/lib/spi/spi_nif.ex
@@ -25,7 +25,7 @@ defmodule Circuits.SPI.Nif do
     :erlang.nif_error(:nif_not_loaded)
   end
 
-  def max_buf_size() do
+  def max_transfer_size() do
     :erlang.nif_error(:nif_not_loaded)
   end
 end

--- a/lib/spi/spi_nif.ex
+++ b/lib/spi/spi_nif.ex
@@ -13,7 +13,7 @@ defmodule Circuits.SPI.Nif do
     :erlang.nif_error(:nif_not_loaded)
   end
 
-  def transfer(_ref, _data, _chunk_size) do
+  def transfer(_ref, _data) do
     :erlang.nif_error(:nif_not_loaded)
   end
 

--- a/lib/spi/spi_nif.ex
+++ b/lib/spi/spi_nif.ex
@@ -13,7 +13,7 @@ defmodule Circuits.SPI.Nif do
     :erlang.nif_error(:nif_not_loaded)
   end
 
-  def transfer(_ref, _data) do
+  def transfer(_ref, _data, _chunk_size) do
     :erlang.nif_error(:nif_not_loaded)
   end
 

--- a/src/hal_spidev.c
+++ b/src/hal_spidev.c
@@ -19,6 +19,7 @@
 #include "spi_nif.h"
 #include <linux/spi/spidev.h>
 #include <sys/types.h>
+#include <inttypes.h>
 
 #ifndef _IOC_SIZE_BITS
 // Include <asm/ioctl.h> manually on platforms that don't include it
@@ -47,7 +48,7 @@ ERL_NIF_TERM hal_max_buf_size(ErlNifEnv *env)
     // Linux put this information (if available) in /sys/module/spidev/parameters/bufsiz
     FILE *file = fopen("/sys/module/spidev/parameters/bufsiz","r");
     if (file != NULL) {
-        fscanf(file, "%llu", &bufsiz);
+        fscanf(file, "%"PRIu64, &bufsiz);
         fclose(file);
         cached = 1;
     }

--- a/src/hal_spidev.c
+++ b/src/hal_spidev.c
@@ -36,22 +36,15 @@ ERL_NIF_TERM hal_info(ErlNifEnv *env)
 
 ERL_NIF_TERM hal_max_buf_size(ErlNifEnv *env)
 {
-    static int cached = 0;
-    static ERL_NIF_TERM max_buf_size;
-    uint64_t bufsiz;
-
-    // use cached max_buf_size
-    if (cached != 0) {
-        return max_buf_size;
-    }
+    ERL_NIF_TERM max_buf_size;
+    uint64_t bufsiz = 0;
 
     // Linux put this information (if available) in /sys/module/spidev/parameters/bufsiz
     FILE *file = fopen("/sys/module/spidev/parameters/bufsiz","r");
     if (file != NULL) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result"
-        fscanf(file, "%"PRIu64, &bufsiz);
-#pragma GCC diagnostic pop
+        if (fscanf(file, "%"PRIu64, &bufsiz) != 1) {
+            bufsiz = 0;
+        }
         fclose(file);
     }
 
@@ -61,7 +54,6 @@ ERL_NIF_TERM hal_max_buf_size(ErlNifEnv *env)
         max_buf_size = enif_make_atom(env, "unknown");
     } else {
         max_buf_size = enif_make_uint64(env, bufsiz);
-        cached = 1;
     }
 
     return max_buf_size;

--- a/src/hal_spidev.c
+++ b/src/hal_spidev.c
@@ -54,8 +54,8 @@ ERL_NIF_TERM hal_max_buf_size(ErlNifEnv *env)
 
     if (bufsiz == 0) {
         // if /sys/module/spidev/parameters/bufsiz is not available
-        // then we return a default value
-        max_buf_size = enif_make_uint64(env, 65536);
+        // then we return :unknown
+        max_buf_size = enif_make_atom(env, "unknown");
     } else {
         max_buf_size = enif_make_uint64(env, bufsiz);
     }

--- a/src/hal_spidev.c
+++ b/src/hal_spidev.c
@@ -34,9 +34,8 @@ ERL_NIF_TERM hal_info(ErlNifEnv *env)
     return info;
 }
 
-ERL_NIF_TERM hal_max_buf_size(ErlNifEnv *env)
+ERL_NIF_TERM hal_max_transfer_size(ErlNifEnv *env)
 {
-    ERL_NIF_TERM max_buf_size;
     uint64_t bufsiz = 0;
 
     // Linux put this information (if available) in /sys/module/spidev/parameters/bufsiz
@@ -51,12 +50,10 @@ ERL_NIF_TERM hal_max_buf_size(ErlNifEnv *env)
     if (bufsiz == 0) {
         // if /sys/module/spidev/parameters/bufsiz is not available
         // then we return 4096, a safe minimum size
-        max_buf_size = enif_make_uint64(env, 4096);
-    } else {
-        max_buf_size = enif_make_uint64(env, bufsiz);
+        bufsiz = 4096;
     }
 
-    return max_buf_size;
+    return enif_make_uint64(env, bufsiz);
 }
 
 int hal_spi_open(const char *device,

--- a/src/hal_spidev.c
+++ b/src/hal_spidev.c
@@ -53,7 +53,6 @@ ERL_NIF_TERM hal_max_buf_size(ErlNifEnv *env)
         fscanf(file, "%"PRIu64, &bufsiz);
 #pragma GCC diagnostic pop
         fclose(file);
-        cached = 1;
     }
 
     if (bufsiz == 0) {
@@ -62,6 +61,7 @@ ERL_NIF_TERM hal_max_buf_size(ErlNifEnv *env)
         max_buf_size = enif_make_atom(env, "unknown");
     } else {
         max_buf_size = enif_make_uint64(env, bufsiz);
+        cached = 1;
     }
 
     return max_buf_size;

--- a/src/hal_spidev.c
+++ b/src/hal_spidev.c
@@ -50,8 +50,8 @@ ERL_NIF_TERM hal_max_buf_size(ErlNifEnv *env)
 
     if (bufsiz == 0) {
         // if /sys/module/spidev/parameters/bufsiz is not available
-        // then we return :unknown
-        max_buf_size = enif_make_atom(env, "unknown");
+        // then we return 4096, a safe minimum size
+        max_buf_size = enif_make_uint64(env, 4096);
     } else {
         max_buf_size = enif_make_uint64(env, bufsiz);
     }

--- a/src/hal_stub.c
+++ b/src/hal_stub.c
@@ -50,8 +50,7 @@ int hal_spi_transfer(int fd,
                      const struct SpiConfig *config,
                      const uint8_t *to_write,
                      uint8_t *to_read,
-                     size_t len,
-                     size_t chunk_size)
+                     size_t len)
 {
     // Loop back.
     memcpy(to_read, to_write, len);

--- a/src/hal_stub.c
+++ b/src/hal_stub.c
@@ -27,11 +27,10 @@ ERL_NIF_TERM hal_info(ErlNifEnv *env)
     return info;
 }
 
-ERL_NIF_TERM hal_max_buf_size(ErlNifEnv *env)
+ERL_NIF_TERM hal_max_transfer_size(ErlNifEnv *env)
 {
-    uint64_t max = 0;
-    max -= 1;
-    return enif_make_uint64(env, max);
+    // Use Linux's default maximum transfer size
+    return enif_make_uint64(env, 4096);
 }
 
 int hal_spi_open(const char *device,

--- a/src/hal_stub.c
+++ b/src/hal_stub.c
@@ -50,7 +50,8 @@ int hal_spi_transfer(int fd,
                      const struct SpiConfig *config,
                      const uint8_t *to_write,
                      uint8_t *to_read,
-                     size_t len)
+                     size_t len,
+                     size_t chunk_size)
 {
     // Loop back.
     memcpy(to_read, to_write, len);

--- a/src/hal_stub.c
+++ b/src/hal_stub.c
@@ -18,12 +18,20 @@
 
 #include "spi_nif.h"
 #include <string.h>
+#include <sys/types.h>
 
 ERL_NIF_TERM hal_info(ErlNifEnv *env)
 {
     ERL_NIF_TERM info = enif_make_new_map(env);
     enif_make_map_put(env, info, enif_make_atom(env, "name"), enif_make_atom(env, "stub"), &info);
     return info;
+}
+
+ERL_NIF_TERM hal_max_buf_size(ErlNifEnv *env)
+{
+    uint64_t max = 0;
+    max -= 1;
+    return enif_make_uint64(env, max);
 }
 
 int hal_spi_open(const char *device,

--- a/src/spi_nif.c
+++ b/src/spi_nif.c
@@ -184,7 +184,7 @@ static ERL_NIF_TERM spi_max_buf_size(ErlNifEnv *env, int argc, const ERL_NIF_TER
 static ErlNifFunc nif_funcs[] =
 {
     {"open", 5, spi_open, ERL_NIF_DIRTY_JOB_IO_BOUND},
-    {"transfer", 3, spi_transfer, 0},
+    {"transfer", 2, spi_transfer, 0},
     {"close", 1, spi_close, 0},
     {"info", 0, spi_info, 0},
     {"max_buf_size", 0, spi_max_buf_size, ERL_NIF_DIRTY_JOB_IO_BOUND}

--- a/src/spi_nif.c
+++ b/src/spi_nif.c
@@ -126,7 +126,6 @@ static ERL_NIF_TERM spi_transfer(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
     ErlNifBinary bin_write;
     ERL_NIF_TERM bin_read;
     unsigned char *raw_bin_read;
-    size_t chunk_size;
 
     debug("spi_transfer");
     if (!enif_get_resource(env, argv[0], priv->spi_nif_res_type, (void **)&res))
@@ -135,18 +134,12 @@ static ERL_NIF_TERM spi_transfer(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
     if (!enif_inspect_binary(env, argv[1], &bin_write))
         return enif_make_badarg(env);
 
-    ErlNifUInt64 u64;
-    if (!enif_get_uint64(env, argv[2], (ErlNifUInt64 *)&u64))
-        chunk_size = bin_write.size;
-    else
-        chunk_size = u64;
-
     raw_bin_read = enif_make_new_binary(env, bin_write.size, &bin_read);
     if (!raw_bin_read)
         return enif_make_tuple2(env, priv->atom_error,
                                 enif_make_atom(env, "alloc_failed"));
 
-    if (hal_spi_transfer(res->fd, &res->config, bin_write.data, raw_bin_read, bin_write.size, chunk_size) < 0)
+    if (hal_spi_transfer(res->fd, &res->config, bin_write.data, raw_bin_read, bin_write.size) < 0)
         return enif_make_tuple2(env, priv->atom_error,
                                 enif_make_atom(env, "transfer_failed"));
 

--- a/src/spi_nif.c
+++ b/src/spi_nif.c
@@ -169,12 +169,18 @@ static ERL_NIF_TERM spi_info(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]
     return hal_info(env);
 }
 
+static ERL_NIF_TERM spi_max_buf_size(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    return hal_max_buf_size(env);
+}
+
 static ErlNifFunc nif_funcs[] =
 {
     {"open", 5, spi_open, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"transfer", 2, spi_transfer, 0},
     {"close", 1, spi_close, 0},
-    {"info", 0, spi_info, 0}
+    {"info", 0, spi_info, 0},
+    {"max_buf_size", 0, spi_max_buf_size, 0}
 };
 
 ERL_NIF_INIT(Elixir.Circuits.SPI.Nif, nif_funcs, spi_load, NULL, NULL, spi_unload)

--- a/src/spi_nif.c
+++ b/src/spi_nif.c
@@ -169,9 +169,9 @@ static ERL_NIF_TERM spi_info(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]
     return hal_info(env);
 }
 
-static ERL_NIF_TERM spi_max_buf_size(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+static ERL_NIF_TERM spi_max_transfer_size(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
-    return hal_max_buf_size(env);
+    return hal_max_transfer_size(env);
 }
 
 static ErlNifFunc nif_funcs[] =
@@ -180,7 +180,7 @@ static ErlNifFunc nif_funcs[] =
     {"transfer", 2, spi_transfer, 0},
     {"close", 1, spi_close, 0},
     {"info", 0, spi_info, 0},
-    {"max_buf_size", 0, spi_max_buf_size, ERL_NIF_DIRTY_JOB_IO_BOUND}
+    {"max_transfer_size", 0, spi_max_transfer_size, ERL_NIF_DIRTY_JOB_IO_BOUND}
 };
 
 ERL_NIF_INIT(Elixir.Circuits.SPI.Nif, nif_funcs, spi_load, NULL, NULL, spi_unload)

--- a/src/spi_nif.c
+++ b/src/spi_nif.c
@@ -187,7 +187,7 @@ static ErlNifFunc nif_funcs[] =
     {"transfer", 3, spi_transfer, 0},
     {"close", 1, spi_close, 0},
     {"info", 0, spi_info, 0},
-    {"max_buf_size", 0, spi_max_buf_size, 0}
+    {"max_buf_size", 0, spi_max_buf_size, ERL_NIF_DIRTY_JOB_IO_BOUND}
 };
 
 ERL_NIF_INIT(Elixir.Circuits.SPI.Nif, nif_funcs, spi_load, NULL, NULL, spi_unload)

--- a/src/spi_nif.h
+++ b/src/spi_nif.h
@@ -46,12 +46,12 @@ struct SpiConfig {
 ERL_NIF_TERM hal_info(ErlNifEnv *env);
 
 /**
- * Return max buffer size about the HAL.
+ * Return max transfer size about the HAL.
  *
  * This should return an unsigned 64-bit int value that indicates the
- * max buffer size in bytes
+ * maximum transfer size in bytes
  */
-ERL_NIF_TERM hal_max_buf_size(ErlNifEnv *env);
+ERL_NIF_TERM hal_max_transfer_size(ErlNifEnv *env);
 
 /**
  * Open an SPI device

--- a/src/spi_nif.h
+++ b/src/spi_nif.h
@@ -46,6 +46,14 @@ struct SpiConfig {
 ERL_NIF_TERM hal_info(ErlNifEnv *env);
 
 /**
+ * Return max buffer size about the HAL.
+ *
+ * This should return an unsigned 64-bit int value that indicates the
+ * max buffer size in bytes
+ */
+ERL_NIF_TERM hal_max_buf_size(ErlNifEnv *env);
+
+/**
  * Open an SPI device
  *
  * @param device the name of the SPI device

--- a/src/spi_nif.h
+++ b/src/spi_nif.h
@@ -77,12 +77,14 @@ void hal_spi_close(int fd);
  * @param to_write
  * @param to_read
  * @param len
+ * @param chunk_size
  * @return
  */
 int hal_spi_transfer(int fd,
                      const struct SpiConfig *config,
                      const uint8_t *to_write,
                      uint8_t *to_read,
-                     size_t len);
+                     size_t len,
+                     size_t chunk_size);
 
 #endif // SPI_NIF_H

--- a/src/spi_nif.h
+++ b/src/spi_nif.h
@@ -77,14 +77,12 @@ void hal_spi_close(int fd);
  * @param to_write
  * @param to_read
  * @param len
- * @param chunk_size
  * @return
  */
 int hal_spi_transfer(int fd,
                      const struct SpiConfig *config,
                      const uint8_t *to_write,
                      uint8_t *to_read,
-                     size_t len,
-                     size_t chunk_size);
+                     size_t len);
 
 #endif // SPI_NIF_H

--- a/test/circuits_spi_test.exs
+++ b/test/circuits_spi_test.exs
@@ -8,10 +8,13 @@ defmodule CircuitsSPITest do
     assert Map.has_key?(info, :name)
   end
 
-  test "max buffer size returns an non-negative integer" do
-    max_buf_size = Circuits.SPI.max_buf_size()
-
-    assert is_integer(max_buf_size)
-    assert (max_buf_size >= 0)
+  test "max buffer size returns an non-negative integer or :unknown" do
+    case Circuits.SPI.max_buf_size()
+    do
+        :unknown -> true
+        max_buf_size ->
+          assert is_integer(max_buf_size)
+          assert (max_buf_size >= 0)
+    end
   end
 end

--- a/test/circuits_spi_test.exs
+++ b/test/circuits_spi_test.exs
@@ -8,14 +8,9 @@ defmodule CircuitsSPITest do
     assert Map.has_key?(info, :name)
   end
 
-  test "max buffer size returns an non-negative integer or :unknown" do
-    case Circuits.SPI.max_buf_size() do
-      :unknown ->
-        true
-
-      max_buf_size ->
-        assert is_integer(max_buf_size)
-        assert max_buf_size >= 0
-    end
+  test "max buffer size returns an non-negative integer" do
+    max_buf_size = Circuits.SPI.max_buf_size()
+    assert is_integer(max_buf_size)
+    assert max_buf_size >= 0
   end
 end

--- a/test/circuits_spi_test.exs
+++ b/test/circuits_spi_test.exs
@@ -9,12 +9,13 @@ defmodule CircuitsSPITest do
   end
 
   test "max buffer size returns an non-negative integer or :unknown" do
-    case Circuits.SPI.max_buf_size()
-    do
-        :unknown -> true
-        max_buf_size ->
-          assert is_integer(max_buf_size)
-          assert (max_buf_size >= 0)
+    case Circuits.SPI.max_buf_size() do
+      :unknown ->
+        true
+
+      max_buf_size ->
+        assert is_integer(max_buf_size)
+        assert max_buf_size >= 0
     end
   end
 end

--- a/test/circuits_spi_test.exs
+++ b/test/circuits_spi_test.exs
@@ -7,4 +7,11 @@ defmodule CircuitsSPITest do
     assert is_map(info)
     assert Map.has_key?(info, :name)
   end
+
+  test "max buffer size returns an non-negative integer" do
+    max_buf_size = Circuits.SPI.max_buf_size()
+
+    assert is_integer(max_buf_size)
+    assert (max_buf_size >= 0)
+  end
 end

--- a/test/circuits_spi_test.exs
+++ b/test/circuits_spi_test.exs
@@ -9,8 +9,8 @@ defmodule CircuitsSPITest do
   end
 
   test "max buffer size returns an non-negative integer" do
-    max_buf_size = Circuits.SPI.max_buf_size()
-    assert is_integer(max_buf_size)
-    assert max_buf_size >= 0
+    max_transfer_size = Circuits.SPI.max_transfer_size()
+    assert is_integer(max_transfer_size)
+    assert max_transfer_size >= 0
   end
 end


### PR DESCRIPTION
Linux put the maximum buffer size of the SPI device at `/sys/module/spidev/parameters/bufsiz`. 

The amount of data in a single transfer must be less than or equal to this number, otherwise, `ioctl` will return a negative value indicating errors. Subsequently, users will get `{:error, :transfer_failed}` in Erlang/Elixir.

This PR added a `max_transfer_size` function to retrieve the maximum buffer size. If `/sys/module/spidev/parameters/bufsiz` is not available, then it returns ~`:unknown`~ `4096`, a safe minimum size in Linux.