### PR TITLE
Allow users to pass in /dev/spidev*

### DIFF
--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -28,7 +28,7 @@ defmodule Circuits.SPI do
   Use reference in subsequent calls to transfer SPI bus data
 
   Parameters:
-  * `bus_name` is the name of the bus (e.g., "spidev0.0")
+  * `bus_name` is the name of the bus (e.g., "spidev0.0"). See `bus_names/0`
   * `opts` is a keyword list to configure the bus
 
   SPI bus options include:

--- a/src/hal_spidev.c
+++ b/src/hal_spidev.c
@@ -60,10 +60,14 @@ int hal_spi_open(const char *device,
                  const struct SpiConfig *config,
                  char *error_str)
 {
-    char devpath[64] = "/dev/";
+    const char *device_path = device;
 
-    strcat(devpath, device);
-    int fd = open(devpath, O_RDWR);
+    char buffer[64] = "/dev/";
+    if (strncmp(device, "/dev/", 5) != 0) {
+        strncat(buffer, device, sizeof(buffer) - 1);
+        device_path = buffer;
+    }
+    int fd = open(device_path, O_RDWR);
     if (fd < 0) {
         strcpy(error_str, "access_denied");
         return -1;


### PR DESCRIPTION
While this isn't mentioned in the docs, now that there's commandline
completion, it's really easy to use it to find the bus. That means that
`open/2` can be passed `"/dev/spidev0.0"`, etc. Rather than returning
access denied, just open the device.
