### PR TITLE
Add support for reversing bit order

### DIFF
--- a/lib/spi/spi_nif.ex
+++ b/lib/spi/spi_nif.ex
@@ -9,7 +9,7 @@ defmodule Circuits.SPI.Nif do
     :erlang.load_nif(to_charlist(nif_binary), 0)
   end
 
-  def open(_bus_name, _mode, _bits_per_word, _speed_hz, _delay_us) do
+  def open(_bus_name, _mode, _bits_per_word, _speed_hz, _delay_us, _lsb_first) do
     :erlang.nif_error(:nif_not_loaded)
   end
 

--- a/src/hal_spidev.c
+++ b/src/hal_spidev.c
@@ -102,6 +102,12 @@ int hal_spi_open(const char *device,
         config->speed_hz = speed_hz;
     }
 
+    uint32_t lsb_first = config->lsb_first;
+    if (ioctl(fd, SPI_IOC_WR_LSB_FIRST, &lsb_first) < 0) {
+        // If not supported by hardware, reverse bits in software
+        config->sw_lsb_first = config->lsb_first;
+    }
+
     return fd;
 }
 

--- a/src/hal_stub.c
+++ b/src/hal_stub.c
@@ -38,6 +38,10 @@ int hal_spi_open(const char *device,
                  char *error_str)
 {
     *error_str = '\0';
+
+    // If reversing the bits, then request that it's done in software
+    config->sw_lsb_first = config->lsb_first;
+
     return 0;
 }
 

--- a/src/spi_nif.c
+++ b/src/spi_nif.c
@@ -89,6 +89,7 @@ static ERL_NIF_TERM spi_open(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]
     if (!enif_get_string(env, argv[0], device, sizeof(device), ERL_NIF_LATIN1))
         return enif_make_badarg(env);
 
+    memset(&config, 0, sizeof(config));
     if (!enif_get_uint(env, argv[1], &config.mode))
         return enif_make_badarg(env);
 
@@ -99,6 +100,9 @@ static ERL_NIF_TERM spi_open(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[]
         return enif_make_badarg(env);
 
     if (!enif_get_uint(env, argv[4], &config.delay_us))
+        return enif_make_badarg(env);
+
+    if (!enif_get_uint(env, argv[5], &config.lsb_first))
         return enif_make_badarg(env);
 
     fd = hal_spi_open(device, &config, error_str);
@@ -133,8 +137,37 @@ static ERL_NIF_TERM spi_config(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv
     enif_make_map_put(env, config, enif_make_atom(env, "bits_per_word"), enif_make_uint(env, res->config.bits_per_word), &config);
     enif_make_map_put(env, config, enif_make_atom(env, "speed_hz"), enif_make_uint(env, res->config.speed_hz), &config);
     enif_make_map_put(env, config, enif_make_atom(env, "delay_us"), enif_make_uint(env, res->config.delay_us), &config);
+    enif_make_map_put(env, config, enif_make_atom(env, "lsb_first"), enif_make_uint(env, res->config.lsb_first), &config);
+    enif_make_map_put(env, config, enif_make_atom(env, "sw_lsb_first"), enif_make_uint(env, res->config.sw_lsb_first), &config);
 
     return enif_make_tuple2(env, priv->atom_ok, config);
+}
+
+static void reverse_bits(uint8_t *dest, const uint8_t *src, size_t len)
+{
+    static const uint8_t reverse[256] = {
+        0x00, 0x80, 0x40, 0xc0, 0x20, 0xa0, 0x60, 0xe0, 0x10, 0x90, 0x50, 0xd0, 0x30, 0xb0, 0x70, 0xf0,
+        0x08, 0x88, 0x48, 0xc8, 0x28, 0xa8, 0x68, 0xe8, 0x18, 0x98, 0x58, 0xd8, 0x38, 0xb8, 0x78, 0xf8,
+        0x04, 0x84, 0x44, 0xc4, 0x24, 0xa4, 0x64, 0xe4, 0x14, 0x94, 0x54, 0xd4, 0x34, 0xb4, 0x74, 0xf4,
+        0x0c, 0x8c, 0x4c, 0xcc, 0x2c, 0xac, 0x6c, 0xec, 0x1c, 0x9c, 0x5c, 0xdc, 0x3c, 0xbc, 0x7c, 0xfc,
+        0x02, 0x82, 0x42, 0xc2, 0x22, 0xa2, 0x62, 0xe2, 0x12, 0x92, 0x52, 0xd2, 0x32, 0xb2, 0x72, 0xf2,
+        0x0a, 0x8a, 0x4a, 0xca, 0x2a, 0xaa, 0x6a, 0xea, 0x1a, 0x9a, 0x5a, 0xda, 0x3a, 0xba, 0x7a, 0xfa,
+        0x06, 0x86, 0x46, 0xc6, 0x26, 0xa6, 0x66, 0xe6, 0x16, 0x96, 0x56, 0xd6, 0x36, 0xb6, 0x76, 0xf6,
+        0x0e, 0x8e, 0x4e, 0xce, 0x2e, 0xae, 0x6e, 0xee, 0x1e, 0x9e, 0x5e, 0xde, 0x3e, 0xbe, 0x7e, 0xfe,
+        0x01, 0x81, 0x41, 0xc1, 0x21, 0xa1, 0x61, 0xe1, 0x11, 0x91, 0x51, 0xd1, 0x31, 0xb1, 0x71, 0xf1,
+        0x09, 0x89, 0x49, 0xc9, 0x29, 0xa9, 0x69, 0xe9, 0x19, 0x99, 0x59, 0xd9, 0x39, 0xb9, 0x79, 0xf9,
+        0x05, 0x85, 0x45, 0xc5, 0x25, 0xa5, 0x65, 0xe5, 0x15, 0x95, 0x55, 0xd5, 0x35, 0xb5, 0x75, 0xf5,
+        0x0d, 0x8d, 0x4d, 0xcd, 0x2d, 0xad, 0x6d, 0xed, 0x1d, 0x9d, 0x5d, 0xdd, 0x3d, 0xbd, 0x7d, 0xfd,
+        0x03, 0x83, 0x43, 0xc3, 0x23, 0xa3, 0x63, 0xe3, 0x13, 0x93, 0x53, 0xd3, 0x33, 0xb3, 0x73, 0xf3,
+        0x0b, 0x8b, 0x4b, 0xcb, 0x2b, 0xab, 0x6b, 0xeb, 0x1b, 0x9b, 0x5b, 0xdb, 0x3b, 0xbb, 0x7b, 0xfb,
+        0x07, 0x87, 0x47, 0xc7, 0x27, 0xa7, 0x67, 0xe7, 0x17, 0x97, 0x57, 0xd7, 0x37, 0xb7, 0x77, 0xf7,
+        0x0f, 0x8f, 0x4f, 0xcf, 0x2f, 0xaf, 0x6f, 0xef, 0x1f, 0x9f, 0x5f, 0xdf, 0x3f, 0xbf, 0x7f, 0xff
+        };
+
+    size_t i;
+    for (i = 0; i < len; i++) {
+        dest[i] = reverse[src[i]];
+    }
 }
 
 static ERL_NIF_TERM spi_transfer(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
@@ -144,6 +177,8 @@ static ERL_NIF_TERM spi_transfer(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
     ErlNifBinary bin_write;
     ERL_NIF_TERM bin_read;
     unsigned char *raw_bin_read;
+    unsigned char *to_write;
+    size_t transfer_size;
 
     debug("spi_transfer");
     if (!enif_get_resource(env, argv[0], priv->spi_nif_res_type, (void **)&res))
@@ -152,14 +187,31 @@ static ERL_NIF_TERM spi_transfer(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
     if (!enif_inspect_binary(env, argv[1], &bin_write))
         return enif_make_badarg(env);
 
-    raw_bin_read = enif_make_new_binary(env, bin_write.size, &bin_read);
+    transfer_size = bin_write.size;
+
+    raw_bin_read = enif_make_new_binary(env, transfer_size, &bin_read);
     if (!raw_bin_read)
         return enif_make_tuple2(env, priv->atom_error,
                                 enif_make_atom(env, "alloc_failed"));
 
-    if (hal_spi_transfer(res->fd, &res->config, bin_write.data, raw_bin_read, bin_write.size) < 0)
+    if (res->config.sw_lsb_first) {
+        to_write = enif_alloc(transfer_size);
+        if (!to_write)
+            return enif_make_tuple2(env, priv->atom_error,
+                                    enif_make_atom(env, "alloc_failed"));
+        reverse_bits(to_write, bin_write.data, transfer_size);
+    } else {
+        to_write = bin_write.data;
+    }
+
+    if (hal_spi_transfer(res->fd, &res->config, to_write, raw_bin_read, transfer_size) < 0)
         return enif_make_tuple2(env, priv->atom_error,
                                 enif_make_atom(env, "transfer_failed"));
+
+    if (res->config.sw_lsb_first) {
+        reverse_bits(raw_bin_read, raw_bin_read, transfer_size);
+        enif_free(to_write);
+    }
 
     return enif_make_tuple2(env, priv->atom_ok, bin_read);
 }
@@ -194,7 +246,7 @@ static ERL_NIF_TERM spi_max_transfer_size(ErlNifEnv *env, int argc, const ERL_NI
 
 static ErlNifFunc nif_funcs[] =
 {
-    {"open", 5, spi_open, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"open", 6, spi_open, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"config", 1, spi_config, 0},
     {"transfer", 2, spi_transfer, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"close", 1, spi_close, 0},

--- a/src/spi_nif.h
+++ b/src/spi_nif.h
@@ -35,6 +35,8 @@ struct SpiConfig {
     unsigned int bits_per_word;
     unsigned int speed_hz;
     unsigned int delay_us;
+    unsigned int lsb_first;
+    unsigned int sw_lsb_first;
 };
 
 /**

--- a/test/circuits_spi_test.exs
+++ b/test/circuits_spi_test.exs
@@ -1,6 +1,9 @@
 defmodule CircuitsSPITest do
   use ExUnit.Case
 
+  # All possible byte values needed for lsb <-> msb test
+  @test_data :binary.list_to_bin(for i <- 0..255, do: i)
+
   test "info returns a map" do
     info = Circuits.SPI.info()
 
@@ -22,5 +25,23 @@ defmodule CircuitsSPITest do
     assert config.bits_per_word == 8
     assert config.delay_us == 10
     assert config.speed_hz == 1_000_000
+    assert config.lsb_first == false
+    assert config.sw_lsb_first == false
+  end
+
+  test "transfers loop back using stub" do
+    {:ok, spi} = Circuits.SPI.open("my_spidev")
+
+    {:ok, result} = Circuits.SPI.transfer(spi, @test_data)
+
+    assert result == @test_data
+  end
+
+  test "transfers loop back using stub and lsb_first" do
+    {:ok, spi} = Circuits.SPI.open("my_spidev", lsb_first: true)
+
+    {:ok, result} = Circuits.SPI.transfer(spi, @test_data)
+
+    assert result == @test_data
   end
 end


### PR DESCRIPTION
This adds the `:lsb_first` option to indicate that the least significant
bit is transferred first rather than the normal way. If the SPI hardware
doesn't support bit reversal, do it in software. This is necessary on
the Raspberry Pi.
