### PR TITLE
Disable gcc overflow warning on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ ifeq ($(CROSSCOMPILE),)
     else
         LDFLAGS += -fPIC -shared
         CFLAGS += -fPIC
+
+	# SPI_IOC_RD_* macros trigger this warning when passed to ioctl on some
+	# Linux/gcc combinations that don't seem to be used when crosscompiling
+	# with Nerves, so disable.
+	CFLAGS += -Wno-overflow
     endif
 
     # Always use the stub when testing


### PR DESCRIPTION
This "fixes" the following:

```
 CC hal_spidev.o
src/hal_spidev.c: In function 'hal_spi_open':
src/hal_spidev.c:83:19: warning: overflow in conversion from 'long unsigned int' to 'int' changes value from '2147576577' to '-2147390719' [-Woverflow]
   83 |     if (ioctl(fd, SPI_IOC_RD_MODE, &mode) == 0) {
      |                   ^~~~~~~~~~~~~~~
src/hal_spidev.c:92:19: warning: overflow in conversion from 'long unsigned int' to 'int' changes value from '2147576579' to '-2147390717' [-Woverflow]
   92 |     if (ioctl(fd, SPI_IOC_RD_BITS_PER_WORD, &bits_per_word) == 0) {
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~
src/hal_spidev.c:101:19: warning: overflow in conversion from 'long unsigned int' to 'int' changes value from '2147773188' to '-2147194108' [-Woverflow]
  101 |     if (ioctl(fd, SPI_IOC_RD_MAX_SPEED_HZ, &speed_hz) == 0) {
      |                   ^~~~~~~~~~~~~~~~~~~~~~~
```

It appears to only affect some gcc/Linux combinations and those appear
to not be Nerves ones. I assume the spec for ioctl was adjusted to fix
this warning at some point.
