### PR TITLE
Support passing iodata to transfer/2

### DIFF
--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -91,13 +91,21 @@ defmodule Circuits.SPI do
   end
 
   @doc """
-  Perform a SPI transfer. The `data` should be a binary containing the bytes to
-  send. Since SPI transfers simultaneously send and receive, the return value
-  will be a binary of the same length or an error.
+  Transfer data
+
+  Since each SPI transfer sends and receives simultaneously, the return value
+  will be a binary of the same length as `data`.
   """
-  @spec transfer(spi_bus(), binary()) :: {:ok, binary()} | {:error, term()}
-  def transfer(spi_bus, data) when is_binary(data) do
-    Nif.transfer(spi_bus, data)
+  @spec transfer(spi_bus(), iodata()) :: {:ok, binary()} | {:error, term()}
+  def transfer(spi_bus, data) do
+    # Flatten the iodata here rather than in the NIF.
+    # In theory, this could be done in the NIF and the Linux kernel could do
+    # the reassembly. I'm not 100% sure this is a performance improvement
+    # except possibly for people sending to SPI displays. If you're seeing this
+    # and using a SPI display and using iodata and hitting a performance issue
+    # that's not improved by raising the SPI bus speed, this might be worth
+    # trying.
+    Nif.transfer(spi_bus, IO.iodata_to_binary(data))
   end
 
   @doc """

--- a/test/circuits_spi_test.exs
+++ b/test/circuits_spi_test.exs
@@ -44,4 +44,15 @@ defmodule CircuitsSPITest do
 
     assert result == @test_data
   end
+
+  test "iodata transfers work" do
+    {:ok, spi} = Circuits.SPI.open("my_spidev", lsb_first: true)
+
+    message = ["Hello", [1, 2, 3, @test_data]]
+    expected = IO.iodata_to_binary(message)
+
+    {:ok, result} = Circuits.SPI.transfer(spi, message)
+
+    assert result == expected
+  end
 end


### PR DESCRIPTION
This is a very minimal update to allow iodata to be used for
convenience. It doesn't enable better performance. I left a note about
my performance doubts. It would be interesting to see what happens in
the future for users with larger SPI transfers than me.

Fixes #52.
