### PR TITLE
Add transfer!/2

### DIFF
--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -108,6 +108,9 @@ defmodule Circuits.SPI do
     Nif.transfer(spi_bus, IO.iodata_to_binary(data))
   end
 
+  @doc """
+  Transfer data and raise on error
+  """
   @spec transfer!(spi_bus(), iodata()) :: binary()
   def transfer!(spi_bus, data) do
     case transfer(spi_bus, data) do

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -108,6 +108,17 @@ defmodule Circuits.SPI do
     Nif.transfer(spi_bus, IO.iodata_to_binary(data))
   end
 
+  @spec transfer!(spi_bus(), iodata()) :: binary()
+  def transfer!(spi_bus, data) do
+    case transfer(spi_bus, data) do
+      {:error, reason} ->
+        raise "SPI failure: " <> to_string(reason)
+
+      {:ok, result} ->
+        result
+    end
+  end
+
   @doc """
   Release any resources associated with the given file descriptor
   """


### PR DESCRIPTION
This is a minor enhancement. I thought it would be nice to have an error-raising variant of [`transfer/2`](https://hexdocs.pm/circuits_spi/Circuits.SPI.html#transfer/2) just like [`circuits_i2c`](https://hexdocs.pm/circuits_i2c/Circuits.I2C.html) does.