### PR TITLE
Port NIF updates from circuits_i2c

### DIFF
--- a/c_src/hal_spidev.c
+++ b/c_src/hal_spidev.c
@@ -42,17 +42,10 @@ ERL_NIF_TERM hal_max_transfer_size(ErlNifEnv *env)
     return enif_make_uint64(env, bufsiz);
 }
 
-int hal_spi_open(const char *device,
+int hal_spi_open(const char *device_path,
                  struct SpiConfig *config,
                  char *error_str)
 {
-    const char *device_path = device;
-
-    char buffer[64] = "/dev/";
-    if (strncmp(device, "/dev/", 5) != 0) {
-        strncat(buffer, device, sizeof(buffer) - 1);
-        device_path = buffer;
-    }
     int fd = open(device_path, O_RDWR);
     if (fd < 0) {
         strcpy(error_str, "access_denied");

--- a/c_src/hal_stub.c
+++ b/c_src/hal_stub.c
@@ -19,7 +19,7 @@ ERL_NIF_TERM hal_max_transfer_size(ErlNifEnv *env)
     return enif_make_uint64(env, 4096);
 }
 
-int hal_spi_open(const char *device,
+int hal_spi_open(const char *device_path,
                  struct SpiConfig *config,
                  char *error_str)
 {

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -78,7 +78,7 @@ defmodule Circuits.SPI do
     delay_us = Keyword.get(opts, :delay_us, 10)
     lsb_first = if Keyword.get(opts, :lsb_first), do: 1, else: 0
 
-    Nif.open(to_charlist(bus_name), mode, bits_per_word, speed_hz, delay_us, lsb_first)
+    Nif.open(to_string(bus_name), mode, bits_per_word, speed_hz, delay_us, lsb_first)
   end
 
   @doc """
@@ -102,14 +102,7 @@ defmodule Circuits.SPI do
   """
   @spec transfer(spi_bus(), iodata()) :: {:ok, binary()} | {:error, term()}
   def transfer(spi_bus, data) do
-    # Flatten the iodata here rather than in the NIF.
-    # In theory, this could be done in the NIF and the Linux kernel could do
-    # the reassembly. I'm not 100% sure this is a performance improvement
-    # except possibly for people sending to SPI displays. If you're seeing this
-    # and using a SPI display and using iodata and hitting a performance issue
-    # that's not improved by raising the SPI bus speed, this might be worth
-    # trying.
-    Nif.transfer(spi_bus, IO.iodata_to_binary(data))
+    Nif.transfer(spi_bus, data)
   end
 
   @doc """


### PR DESCRIPTION
This has the following changes:

1. Change filename to be an Elixir string rather than an Erlang one in
   the NIF. There's no external API change.
2. Push iodata to binary conversion down to C. The performance is
   roughly the same as flatting in Elixir, but lowering it in the stack
   will come in handy for the future swappable backend change.
3. Various minor code style changes to look more like circuits_i2c C.

While circuits_i2c switched to a one C file, that was harder to do here
and not introduce a lot of compatibility header files to compile on
MacOS.
