### PR TITLE
Defer loading the NIF until opening a SPI bus (v1.x branch)

### DIFF
--- a/lib/spi/spi_nif.ex
+++ b/lib/spi/spi_nif.ex
@@ -3,18 +3,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 defmodule Circuits.SPI.Nif do
-  @on_load {:load_nif, 0}
-  @compile {:autoload, false}
-
   @moduledoc false
 
-  def load_nif() do
+  defp load_nif() do
     nif_binary = Application.app_dir(:circuits_spi, "priv/spi_nif")
     :erlang.load_nif(to_charlist(nif_binary), 0)
   end
 
-  def open(_bus_name, _mode, _bits_per_word, _speed_hz, _delay_us, _lsb_first) do
-    :erlang.nif_error(:nif_not_loaded)
+  def open(bus_name, mode, bits_per_word, speed_hz, delay_us, lsb_first) do
+    with :ok <- load_nif() do
+      apply(__MODULE__, :open, [bus_name, mode, bits_per_word, speed_hz, delay_us, lsb_first])
+    end
   end
 
   def config(_ref) do
@@ -30,7 +29,8 @@ defmodule Circuits.SPI.Nif do
   end
 
   def info() do
-    :erlang.nif_error(:nif_not_loaded)
+    :ok = load_nif()
+    apply(__MODULE__, :info, [])
   end
 
   def max_transfer_size() do


### PR DESCRIPTION
This change moves the NIF load from the time at which the module is
loaded to the time when SPI actually is used.

The primary motivation for doing this is to defer native code crashes
from happening at load time to the time of first use. Load time is
harder to debug and sometimes its not clear which NIF caused the crash.

The calls to `apply` get around some complexity with ignoring Dialyzer
warnings. Dialyzer can't figure out that the recursive looking call
actually invokes the NIF code.
