### PR TITLE
Fix race condition when loading the NIF

### DIFF
--- a/test/circuits_spi_test.exs
+++ b/test/circuits_spi_test.exs
@@ -62,4 +62,20 @@ defmodule CircuitsSPITest do
 
     assert result == expected
   end
+
+  test "racing to load the NIF" do
+    # Make sure the NIF isn't loaded
+    _ = :code.delete(Circuits.SPI.Nif)
+    _ = :code.purge(Circuits.SPI.Nif)
+
+    # Try to hit the race by having 32 processes race to load the NIF
+    tasks =
+      for _ <- 0..31 do
+        Task.async(fn ->
+          _ = Circuits.SPI.info()
+        end)
+      end
+
+    Enum.each(tasks, &Task.await/1)
+  end
 end


### PR DESCRIPTION
Previously the second load would fail and in this case was able to cause
a segfault.
