### PR TITLE
Remove deferred loading of NIF

### DIFF
--- a/lib/spi/spi_nif.ex
+++ b/lib/spi/spi_nif.ex
@@ -5,27 +5,19 @@
 defmodule Circuits.SPI.Nif do
   @moduledoc false
 
-  defp load_nif_and_apply(fun, args) do
-    nif_binary = Application.app_dir(:circuits_spi, "priv/spi_nif")
+  @on_load {:load_nif, 0}
+  @compile {:autoload, false}
 
-    # Optimistically load the NIF. Handle the possible race.
-    case :erlang.load_nif(to_charlist(nif_binary), 0) do
-      :ok -> apply(__MODULE__, fun, args)
-      {:error, {:reload, _}} -> apply(__MODULE__, fun, args)
-      error -> error
-    end
+  def load_nif() do
+    :erlang.load_nif(:code.priv_dir(:circuits_spi) ++ ~c"/spi_nif", 0)
   end
 
-  def open(bus_name, mode, bits_per_word, speed_hz, delay_us, lsb_first) do
-    load_nif_and_apply(:open, [bus_name, mode, bits_per_word, speed_hz, delay_us, lsb_first])
-  end
+  def open(_bus_name, _mode, _bits_per_word, _speed_hz, _delay_us, _lsb_first),
+    do: :erlang.nif_error(:nif_not_loaded)
 
   def config(_ref), do: :erlang.nif_error(:nif_not_loaded)
   def transfer(_ref, _data), do: :erlang.nif_error(:nif_not_loaded)
   def close(_ref), do: :erlang.nif_error(:nif_not_loaded)
   def max_transfer_size(), do: :erlang.nif_error(:nif_not_loaded)
-
-  def info() do
-    load_nif_and_apply(:info, [])
-  end
+  def info(), do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/test/circuits_spi_test.exs
+++ b/test/circuits_spi_test.exs
@@ -62,20 +62,4 @@ defmodule CircuitsSPITest do
 
     assert result == expected
   end
-
-  test "racing to load the NIF" do
-    # Make sure the NIF isn't loaded
-    _ = :code.delete(Circuits.SPI.Nif)
-    _ = :code.purge(Circuits.SPI.Nif)
-
-    # Try to hit the race by having 32 processes race to load the NIF
-    tasks =
-      for _ <- 0..31 do
-        Task.async(fn ->
-          _ = Circuits.SPI.info()
-        end)
-      end
-
-    Enum.each(tasks, &Task.await/1)
-  end
 end


### PR DESCRIPTION
It was possible to crash the BEAM by loading a completely trimmed down
shared library with multiple processes. This converts the NIF loader
back to the traditional `@on_load` way that's serialized by the code
loader. The benefits of delaying the load time are less now that the
shared library has been tested quite a bit.
