### PR TITLE
Improve target detection for building spi-dev

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -83,8 +83,16 @@ defmodule Circuits.SPI.MixProject do
     end
   end
 
-  # Assume Nerves for a default
-  defp default_backend(_env, _not_host), do: Circuits.SPI.SPIDev
+  # MIX_TARGET set to something besides host
+  defp default_backend(env, _not_host) do
+    # If CROSSCOMPILE is set, then the Makefile will use the crosscompiler and
+    # assume a Linux/Nerves build If not, then the NIF will be build for the
+    # host, so use the default host backend
+    case System.fetch_env("CROSSCOMPILE") do
+      {:ok, _} -> Circuits.SPI.SPIDev
+      :error -> default_backend(env, :host)
+    end
+  end
 
   defp set_make_env(_args) do
     # Since user configuration hasn't been loaded into the application


### PR DESCRIPTION
It turns out that people sometimes have MIX_TARGET set when they're not
compiling for Nerves. On MacOS which doesn't support cdev, this causes
the following error:

```
==> circuits_spi
"**** CIRCUITS_SPI_BACKEND set to [normal] ****"
Makefile:44: *** Circuits.SPI Linux cdev backend is not supported on non-Linux platforms. Review circuits_spi backend configuration or report an issue if improperly detected..  Stop.
could not compile dependency :circuits_spi, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile circuits_spi --force", update it with "mix deps.update circuits_spi" or clean it with "mix deps.clean circuits_spi"
```

This is pretty confusing. This change makes the Nerves detection smarter
by first checking the MIX_TARGET and then checking if crosscompilation
environment variables are actually set. If not, the host compiler will
be used, so use the default for host builds.
