### PR TITLE
Explain lsb-first-related error message

### DIFF
--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -34,6 +34,9 @@ defmodule Circuits.SPI do
   * `delay_us` - Set the delay between transactions (10)
   * `lsb_first` - Set to `true` to send the least significant bit first rather
     than the most significant one. (false)
+    The error message `unsupported mode bits 8` might be printed due to
+    hardware that doesn't support the LSB-first mode, which can be ignored
+    since Circuits.SPI handles it automatically.
   """
   @type spi_option() ::
           {:mode, 0..3}


### PR DESCRIPTION
An error is printed to standard error by Linux Kernel when hardware doesn't support the LSB-first mode. It is benign in our context since Circuits.SPI handles it automatically; however, currently there's no way of fixing this since Linux Kernel doesn't have an API to check support for the LSB first mode without printing that error message. The way that Linux Kernel figures out whether the LSB first mode is supported prints that error message.

Related: https://github.com/fhunleth/binary_clock/pull/3