### PR TITLE
Fixing docu, copy&paste typo

### DIFF
--- a/lib/spi/nil_backend.ex
+++ b/lib/spi/nil_backend.ex
@@ -19,7 +19,7 @@ defmodule Circuits.SPI.NilBackend do
   def bus_names(_options), do: []
 
   @doc """
-  Open an I2C bus
+  Open an SPI bus
 
   No supported options.
   """


### PR DESCRIPTION
The documentation is wrong, since this is the SPI library and not the I2C library. Probably a simple Copy&Paste error