### PR TITLE
Segment large buffers in the NIF

### DIFF
--- a/c_src/hal_spidev.c
+++ b/c_src/hal_spidev.c
@@ -14,6 +14,27 @@
 #include <asm/ioctl.h>
 #endif
 
+static unsigned int get_max_transfer_size()
+{
+    unsigned int bufsiz = 0;
+
+    // Linux puts this information (if available) in /sys/module/spidev/parameters/bufsiz
+    FILE *fp = fopen("/sys/module/spidev/parameters/bufsiz","r");
+    if (fp != NULL) {
+        if (fscanf(fp, "%u", &bufsiz) != 1) {
+            bufsiz = 0;
+        }
+        fclose(fp);
+    }
+
+    if (bufsiz == 0) {
+        // if /sys/module/spidev/parameters/bufsiz is not available
+        // then we return 4096, a safe minimum size
+        bufsiz = 4096;
+    }
+    return bufsiz;
+}
+
 ERL_NIF_TERM hal_info(ErlNifEnv *env)
 {
     ERL_NIF_TERM info = enif_make_new_map(env);
@@ -23,24 +44,7 @@ ERL_NIF_TERM hal_info(ErlNifEnv *env)
 
 ERL_NIF_TERM hal_max_transfer_size(ErlNifEnv *env)
 {
-    uint64_t bufsiz = 0;
-
-    // Linux puts this information (if available) in /sys/module/spidev/parameters/bufsiz
-    FILE *file = fopen("/sys/module/spidev/parameters/bufsiz","r");
-    if (file != NULL) {
-        if (fscanf(file, "%"PRIu64, &bufsiz) != 1) {
-            bufsiz = 0;
-        }
-        fclose(file);
-    }
-
-    if (bufsiz == 0) {
-        // if /sys/module/spidev/parameters/bufsiz is not available
-        // then we return 4096, a safe minimum size
-        bufsiz = 4096;
-    }
-
-    return enif_make_uint64(env, bufsiz);
+    return enif_make_uint(env, get_max_transfer_size());
 }
 
 int hal_spi_open(const char *device_path,
@@ -88,12 +92,35 @@ int hal_spi_open(const char *device_path,
         config->sw_lsb_first = config->lsb_first;
     }
 
+    config->max_transfer_size = get_max_transfer_size();
+
     return fd;
 }
 
 void hal_spi_close(int fd)
 {
     close(fd);
+}
+
+static void chunk(struct spi_ioc_transfer *tfer,
+                  const struct SpiConfig *config,
+                  const uint8_t *to_write,
+                  uint8_t *to_read,
+                  size_t len)
+{
+    memset(tfer, 0, sizeof(*tfer));
+    tfer->speed_hz = config->speed_hz;
+    tfer->delay_usecs = (uint16_t) config->delay_us;
+    tfer->bits_per_word = (uint8_t) config->bits_per_word;
+
+    // The Linux header spidev.h expects pointers to be in 64-bit integers (__u64),
+    // but pointers on Raspberry Pi are only 32 bits.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpointer-to-int-cast"
+    tfer->tx_buf = (__u64) to_write;
+    tfer->rx_buf = (__u64) to_read;
+#pragma GCC diagnostic pop
+    tfer->len = (uint32_t) len;
 }
 
 int hal_spi_transfer(int fd,
@@ -103,20 +130,23 @@ int hal_spi_transfer(int fd,
                      size_t len)
 {
     struct spi_ioc_transfer tfer;
+    const uint8_t *w = to_write;
+    uint8_t *r = to_read;
+    unsigned int max_len = config->max_transfer_size;
 
-    memset(&tfer, 0, sizeof(tfer));
-    tfer.speed_hz = config->speed_hz;
-    tfer.delay_usecs = (uint16_t ) config->delay_us;
-    tfer.bits_per_word = (uint8_t) config->bits_per_word;
+    size_t len_left = len;
+    while (len_left > max_len) {
+        chunk(&tfer, config, w, r, max_len);
+        if (ioctl(fd, SPI_IOC_MESSAGE(1), &tfer) < 0)
+            return -1;
 
-    // The Linux header spidev.h expects pointers to be in 64-bit integers (__u64),
-    // but pointers on Raspberry Pi are only 32 bits.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wpointer-to-int-cast"
-    tfer.tx_buf = (__u64) to_write;
-    tfer.rx_buf = (__u64) to_read;
-#pragma GCC diagnostic pop
-    tfer.len = (uint32_t) len;
+        if (w)
+            w += max_len;
+        if (r)
+            r += max_len;
+        len_left -= max_len;
+    }
+    chunk(&tfer, config, w, r, len_left);
 
     return ioctl(fd, SPI_IOC_MESSAGE(1), &tfer);
 }

--- a/c_src/hal_stub.c
+++ b/c_src/hal_stub.c
@@ -17,7 +17,7 @@ ERL_NIF_TERM hal_info(ErlNifEnv *env)
 ERL_NIF_TERM hal_max_transfer_size(ErlNifEnv *env)
 {
     // Use Linux's default maximum transfer size
-    return enif_make_uint64(env, 4096);
+    return enif_make_uint(env, 4096);
 }
 
 int hal_spi_open(const char *device_path,
@@ -43,7 +43,10 @@ int hal_spi_transfer(int fd,
                      size_t len)
 {
     // Loop back.
-    memcpy(to_read, to_write, len);
+    if (to_read != NULL && to_write != NULL)
+        memcpy(to_read, to_write, len);
+    else if (to_read != NULL)
+        memset(to_read, 0, len);
 
     return 0;
 }

--- a/c_src/spi_nif.h
+++ b/c_src/spi_nif.h
@@ -43,6 +43,7 @@ struct SpiConfig {
     unsigned int delay_us;
     int lsb_first;
     int sw_lsb_first;
+    unsigned int max_transfer_size;
 };
 
 /**
@@ -56,7 +57,7 @@ ERL_NIF_TERM hal_info(ErlNifEnv *env);
 /**
  * Return max transfer size about the HAL.
  *
- * This should return an unsigned 64-bit int value that indicates the
+ * This should return an unsigned int value that indicates the
  * maximum transfer size in bytes
  */
 ERL_NIF_TERM hal_max_transfer_size(ErlNifEnv *env);

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -100,6 +100,10 @@ defmodule Circuits.SPI do
 
   Since each SPI transfer sends and receives simultaneously, the return value
   will be a binary of the same length as `data`.
+
+  Large data buffers are segmented into max-transfer-size chunks internally.
+  This results in multiple SPI transfers and chip select may be deasserted between chunks.
+  If you're observing the SPI bus with a logic analyzer, you may see a short pause between chunks.
   """
   @spec transfer(Bus.t(), iodata()) :: {:ok, binary()} | {:error, term()}
   def transfer(spi_bus, data) do


### PR DESCRIPTION
Rather than error out, just chunk large buffers automatically to spidev based on the max transfer size. This is faster (and easier) than doing it in Elixir.