### PR TITLE
Add read and write functions to reduce unneeded buffers

### DIFF
--- a/c_src/spi_nif.c
+++ b/c_src/spi_nif.c
@@ -221,6 +221,73 @@ static ERL_NIF_TERM spi_transfer(ErlNifEnv *env, int argc, const ERL_NIF_TERM ar
     return enif_make_tuple2(env, atom_ok, bin_read);
 }
 
+static ERL_NIF_TERM spi_write(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    struct SpiNifPriv *priv = enif_priv_data(env);
+    struct SpiNifRes *res;
+    ErlNifBinary bin_write;
+    unsigned char *to_write;
+    size_t transfer_size;
+
+    debug("spi_write");
+    if (!enif_get_resource(env, argv[0], priv->spi_nif_res_type, (void **)&res) ||
+            !enif_inspect_iolist_as_binary(env, argv[1], &bin_write))
+        return enif_make_badarg(env);
+
+    transfer_size = bin_write.size;
+
+    if (res->config.sw_lsb_first) {
+        to_write = enif_alloc(transfer_size);
+        if (!to_write)
+            return enif_make_tuple2(env, atom_error,
+                                    enif_make_atom(env, "alloc_failed"));
+        reverse_bits(to_write, bin_write.data, transfer_size);
+    } else {
+        to_write = bin_write.data;
+    }
+
+    if (hal_spi_transfer(res->fd, &res->config, to_write, NULL, transfer_size) < 0) {
+        if (res->config.sw_lsb_first)
+            enif_free(to_write);
+        return enif_make_tuple2(env, atom_error,
+                                enif_make_atom(env, "transfer_failed"));
+    }
+
+    if (res->config.sw_lsb_first)
+        enif_free(to_write);
+
+    return atom_ok;
+}
+
+static ERL_NIF_TERM spi_read(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    struct SpiNifPriv *priv = enif_priv_data(env);
+    struct SpiNifRes *res;
+    ERL_NIF_TERM bin_read;
+    unsigned char *raw_bin_read;
+    unsigned int transfer_size;
+
+    debug("spi_read");
+    if (!enif_get_resource(env, argv[0], priv->spi_nif_res_type, (void **)&res) ||
+            !enif_get_uint(env, argv[1], &transfer_size))
+        return enif_make_badarg(env);
+
+    raw_bin_read = enif_make_new_binary(env, transfer_size, &bin_read);
+    if (!raw_bin_read)
+        return enif_make_tuple2(env, atom_error,
+                                enif_make_atom(env, "alloc_failed"));
+
+    if (hal_spi_transfer(res->fd, &res->config, NULL, raw_bin_read, transfer_size) < 0)
+        return enif_make_tuple2(env, atom_error,
+                                enif_make_atom(env, "transfer_failed"));
+
+    if (res->config.sw_lsb_first) {
+        reverse_bits(raw_bin_read, raw_bin_read, transfer_size);
+    }
+
+    return enif_make_tuple2(env, atom_ok, bin_read);
+}
+
 static ERL_NIF_TERM spi_close(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
 {
     struct SpiNifPriv *priv = enif_priv_data(env);
@@ -253,6 +320,8 @@ static ErlNifFunc nif_funcs[] =
     {"open", 6, spi_open, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"config", 1, spi_config, 0},
     {"transfer", 2, spi_transfer, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"write", 2, spi_write, ERL_NIF_DIRTY_JOB_IO_BOUND},
+    {"read", 2, spi_read, ERL_NIF_DIRTY_JOB_IO_BOUND},
     {"close", 1, spi_close, 0},
     {"info", 0, spi_info, 0},
     {"max_transfer_size", 0, spi_max_transfer_size, ERL_NIF_DIRTY_JOB_IO_BOUND}

--- a/c_src/spi_nif.h
+++ b/c_src/spi_nif.h
@@ -88,10 +88,10 @@ void hal_spi_close(int fd);
  *
  * @param fd the file descriptor returned from hal_spi_open
  * @param config the SPI configuration to use
- * @param to_write
- * @param to_read
- * @param len
- * @return
+ * @param to_write buffer to write or NULL if writes are ignored
+ * @param to_read buffer to store read data or NULL if not interested
+ * @param len the number of bytes to transfer
+ * @return 0 on success or -1 on error
  */
 int hal_spi_transfer(int fd,
                      const struct SpiConfig *config,

--- a/lib/spi.ex
+++ b/lib/spi.ex
@@ -115,13 +115,45 @@ defmodule Circuits.SPI do
   """
   @spec transfer!(Bus.t(), iodata()) :: binary()
   def transfer!(spi_bus, data) do
-    case transfer(spi_bus, data) do
-      {:error, reason} ->
-        raise "SPI failure: " <> to_string(reason)
+    transfer(spi_bus, data) |> result1!()
+  end
 
-      {:ok, result} ->
-        result
-    end
+  @doc """
+  Write data
+
+  This works identically to transfer/2 except that it ignores all received data.
+  """
+  @spec write(Bus.t(), iodata()) :: :ok | {:error, term()}
+  def write(spi_bus, data) do
+    Bus.write(spi_bus, data)
+  end
+
+  @doc """
+  Write data and raise on error
+  """
+  @spec write!(Bus.t(), iodata()) :: :ok
+  def write!(spi_bus, data) do
+    write(spi_bus, data) |> result2!()
+  end
+
+  @doc """
+  Read len bytes
+
+  This works identically to transfer/2 except that the bits written are whatever
+  the controller chooses. The expectation is that the device on the other side
+  is ignoring them anyway.
+  """
+  @spec read(Bus.t(), pos_integer()) :: {:ok, binary()} | {:error, term()}
+  def read(spi_bus, len) do
+    Bus.read(spi_bus, len)
+  end
+
+  @doc """
+  Read data and raise on error
+  """
+  @spec read!(Bus.t(), pos_integer()) :: binary()
+  def read!(spi_bus, len) do
+    read(spi_bus, len) |> result1!()
   end
 
   @doc """
@@ -158,6 +190,13 @@ defmodule Circuits.SPI do
 
   def info(nil), do: info(default_backend())
   def info({backend, _options}), do: backend.info()
+
+  # The two functions here are for Dialyzer
+  defp result1!({:ok, result}), do: result
+  defp result1!({:error, reason}), do: raise("SPI failure: " <> to_string(reason))
+
+  defp result2!(:ok), do: :ok
+  defp result2!({:error, reason}), do: raise("SPI failure: " <> to_string(reason))
 
   defp default_backend() do
     case Application.get_env(:circuits_spi, :default_backend) do

--- a/lib/spi/bus.ex
+++ b/lib/spi/bus.ex
@@ -28,6 +28,24 @@ defprotocol Circuits.SPI.Bus do
   def transfer(bus, data)
 
   @doc """
+  Write data
+
+  This works identically to transfer/2 except that it ignores all received data.
+  """
+  @spec write(t(), iodata()) :: :ok | {:error, term()}
+  def write(bus, data)
+
+  @doc """
+  Read len bytes
+
+  This works identically to transfer/2 except that the bits written are whatever
+  the controller chooses. The expectation is that the device on the other side
+  is ignoring them anyway.
+  """
+  @spec read(t(), pos_integer()) :: {:ok, binary()} | {:error, term()}
+  def read(bus, len)
+
+  @doc """
   Free up resources associated with the bus
 
   Well behaved backends free up their resources with the help of the Erlang garbage collector. However, it is good

--- a/lib/spi/spi_dev.ex
+++ b/lib/spi/spi_dev.ex
@@ -78,6 +78,16 @@ defmodule Circuits.SPI.SPIDev do
     end
 
     @impl Bus
+    def write(%Circuits.SPI.SPIDev{ref: ref}, data) do
+      Nif.write(ref, data)
+    end
+
+    @impl Bus
+    def read(%Circuits.SPI.SPIDev{ref: ref}, len) do
+      Nif.read(ref, len)
+    end
+
+    @impl Bus
     def close(%Circuits.SPI.SPIDev{ref: ref}) do
       Nif.close(ref)
     end

--- a/lib/spi/spi_nif.ex
+++ b/lib/spi/spi_nif.ex
@@ -19,6 +19,8 @@ defmodule Circuits.SPI.Nif do
 
   def config(_ref), do: :erlang.nif_error(:nif_not_loaded)
   def transfer(_ref, _data), do: :erlang.nif_error(:nif_not_loaded)
+  def write(_ref, _data), do: :erlang.nif_error(:nif_not_loaded)
+  def read(_ref, _len), do: :erlang.nif_error(:nif_not_loaded)
   def close(_ref), do: :erlang.nif_error(:nif_not_loaded)
   def max_transfer_size(), do: :erlang.nif_error(:nif_not_loaded)
   def info(), do: :erlang.nif_error(:nif_not_loaded)

--- a/test/circuits_spi_test.exs
+++ b/test/circuits_spi_test.exs
@@ -63,4 +63,18 @@ defmodule CircuitsSPITest do
 
     assert result == expected
   end
+
+  test "reads return the right number of bytes" do
+    {:ok, spi} = Circuits.SPI.open("my_spidev")
+
+    {:ok, result} = Circuits.SPI.read(spi, 100)
+
+    assert byte_size(result) == 100
+  end
+
+  test "write doesn't crash" do
+    {:ok, spi} = Circuits.SPI.open("my_spidev")
+
+    :ok = Circuits.SPI.write(spi, <<1, 2, 3, 4>>)
+  end
 end


### PR DESCRIPTION
The spidev driver already makes passing buffers in transfers optional so extend that to Elixir. This saves some garbage creation for the common case where only a write is needed.