### PR TITLE
Include useful information in SPI.info()

### DIFF
--- a/c_src/hal_spidev.c
+++ b/c_src/hal_spidev.c
@@ -6,6 +6,7 @@
 #include "spi_nif.h"
 #include <linux/spi/spidev.h>
 #include <sys/types.h>
+#include <sys/utsname.h>
 #include <inttypes.h>
 
 #ifndef _IOC_SIZE_BITS
@@ -35,10 +36,29 @@ static unsigned int get_max_transfer_size()
     return bufsiz;
 }
 
+static ERL_NIF_TERM encode_string(ErlNifEnv *env, const char *str)
+{
+    ERL_NIF_TERM term;
+    unsigned char *buffer = enif_make_new_binary(env, strlen(str), &term);
+    memcpy(buffer, str, strlen(str));
+    return term;
+}
+
 ERL_NIF_TERM hal_info(ErlNifEnv *env)
 {
     ERL_NIF_TERM info = enif_make_new_map(env);
-    enif_make_map_put(env, info, enif_make_atom(env, "name"), enif_make_atom(env, "spidev"), &info);
+    enif_make_map_put(env, info, enif_make_atom(env, "description"), encode_string(env, "Linux spidev driver"), &info);
+
+    struct utsname kernel_info;
+    const char *kernel_version = "unknown";
+    const char *machine = "unknown";
+    if (uname(&kernel_info) == 0) {
+        kernel_version = kernel_info.release;
+        machine = kernel_info.machine;
+    }
+    enif_make_map_put(env, info, enif_make_atom(env, "kernel_version"), encode_string(env, kernel_version), &info);
+    enif_make_map_put(env, info, enif_make_atom(env, "machine"), encode_string(env, machine), &info);
+
     return info;
 }
 


### PR DESCRIPTION
While it's still not much, including that this is a Linux driver and the
kernel version can narrow vague issue reports a little.

```
iex(1)> Circuits.SPI.info
%{
  backend: Circuits.SPI.SPIDev,
  description: "Linux spidev driver",
  kernel_version: "6.18.33-v8"
  machine: "aarch64",
}
```
